### PR TITLE
feat: for...in loop with auto-collect, range() builtin, and list literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-03-26
+
+### Added
+
+- **`for...in` loop with auto-collect** — iterate over lists and collect each iteration's result into a new list: `for x in [1, 2, 3] [x * 10;]` → `10, 20, 30`
+- **Index variable support** — optional second binding: `for val, idx in list [val + idx;]`
+- **`range()` builtin** — `range(count)` and `range(start, end)` for generating integer sequences
+- **Explicit list literal syntax `[a, b, c]`** — bracket-delimited list expressions, matching Go interpreter parity
+- **Loop variable scoping** — item/index variables are cleaned up after the loop; shadowing outer variables is an error (ADR-005)
+- **`return` propagation in loop body** — `return` inside a `for...in` body exits the entire expression
+
 ## [0.30.0] - 2026-03-05
 
 ## [0.29.2] - 2026-03-05

--- a/src/interpreter/ast.ts
+++ b/src/interpreter/ast.ts
@@ -225,6 +225,17 @@ export class WhileNode implements ASTNode {
   ) {}
 }
 
+export class ForEachNode implements ASTNode {
+  nodeType = "ForEachNode";
+  constructor(
+    public itemVar: string,
+    public indexVar: string | null,
+    public collection: ASTNode,
+    public body: StatementListNode,
+    public token?: Token,
+  ) {}
+}
+
 export class IfConditionNode implements ASTNode {
   nodeType = "IfConditionNode";
   constructor(
@@ -318,6 +329,9 @@ export function walkAST(node: ASTNode, onVisit: (node: ASTNode) => void): void {
     walkAST(node.expr, onVisit);
   } else if (node instanceof WhileNode) {
     walkAST(node.condition, onVisit);
+    walkAST(node.body, onVisit);
+  } else if (node instanceof ForEachNode) {
+    walkAST(node.collection, onVisit);
     walkAST(node.body, onVisit);
   } else if (node instanceof IfConditionNode) {
     walkAST(node.condition, onVisit);

--- a/src/interpreter/config/managers/functions/manager.ts
+++ b/src/interpreter/config/managers/functions/manager.ts
@@ -7,7 +7,7 @@ import {
 import { Interpreter } from "@interpreter/interpreter";
 import { Lexer } from "@interpreter/lexer";
 import { Parser } from "@interpreter/parser";
-import { BooleanSymbol, NumberSymbol, StringSymbol } from "@interpreter/symbols";
+import { BooleanSymbol, ListSymbol, NumberSymbol, StringSymbol } from "@interpreter/symbols";
 import type { ISymbolType, Token } from "@src/types";
 import { type } from "arktype";
 import { BaseManager } from "../base-manager";
@@ -152,6 +152,71 @@ export class FunctionsManager extends BaseManager<
 
     this.registerFunction("is_color", (arg: ISymbolType): BooleanSymbol => {
       return new BooleanSymbol(arg.type === "Color");
+    });
+
+    // range(count) or range(start, end) — generate list of integers
+    this.registerFunction("range", (...args: ISymbolType[]): ListSymbol => {
+      if (args.length < 1 || args.length > 2) {
+        throw new InterpreterError(FunctionsErrorCode.REQUIRES_MIN_ARGUMENTS, {
+          data: { functionName: "range", minArgs: 1 },
+        });
+      }
+
+      let start: number;
+      let end: number;
+
+      if (args.length === 1) {
+        // range(count) → [0, 1, ..., count-1]
+        if (!(args[0] instanceof NumberSymbol)) {
+          throw new InterpreterError(FunctionsErrorCode.EXPECTS_TYPE_ARGUMENT, {
+            data: { functionName: "range", expectedType: "Number", argumentPosition: "first" },
+          });
+        }
+        const v = args[0].value as number;
+        if (v !== Math.trunc(v) || Number.isNaN(v) || !Number.isFinite(v) || v < 0 || v > 1e6) {
+          throw new InterpreterError(FunctionsErrorCode.ARGUMENT_OUT_OF_RANGE, {
+            data: { functionName: "range", constraint: `count must be a non-negative integer <= 1000000, got ${v}` },
+          });
+        }
+        start = 0;
+        end = v;
+      } else {
+        // range(start, end) → [start, start+1, ..., end-1]
+        if (!(args[0] instanceof NumberSymbol)) {
+          throw new InterpreterError(FunctionsErrorCode.EXPECTS_TYPE_ARGUMENT, {
+            data: { functionName: "range", expectedType: "Number", argumentPosition: "first" },
+          });
+        }
+        if (!(args[1] instanceof NumberSymbol)) {
+          throw new InterpreterError(FunctionsErrorCode.EXPECTS_TYPE_ARGUMENT, {
+            data: { functionName: "range", expectedType: "Number", argumentPosition: "second" },
+          });
+        }
+        const sv = args[0].value as number;
+        const ev = args[1].value as number;
+        if (sv !== Math.trunc(sv) || ev !== Math.trunc(ev) || Number.isNaN(sv) || Number.isNaN(ev) || !Number.isFinite(sv) || !Number.isFinite(ev)) {
+          throw new InterpreterError(FunctionsErrorCode.ARGUMENT_OUT_OF_RANGE, {
+            data: { functionName: "range", constraint: `arguments must be integers, got ${sv} and ${ev}` },
+          });
+        }
+        if (ev - sv > 1e6) {
+          throw new InterpreterError(FunctionsErrorCode.ARGUMENT_OUT_OF_RANGE, {
+            data: { functionName: "range", constraint: `size exceeds limit (1000000), got ${ev - sv}` },
+          });
+        }
+        start = sv;
+        end = ev;
+      }
+
+      if (end < start) {
+        return new ListSymbol([], false);
+      }
+
+      const elements: NumberSymbol[] = [];
+      for (let i = start; i < end; i++) {
+        elements.push(new NumberSymbol(i));
+      }
+      return new ListSymbol(elements, false);
     });
   }
 

--- a/src/interpreter/config/managers/functions/manager.ts
+++ b/src/interpreter/config/managers/functions/manager.ts
@@ -175,7 +175,10 @@ export class FunctionsManager extends BaseManager<
         const v = args[0].value as number;
         if (v !== Math.trunc(v) || Number.isNaN(v) || !Number.isFinite(v) || v < 0 || v > 1e6) {
           throw new InterpreterError(FunctionsErrorCode.ARGUMENT_OUT_OF_RANGE, {
-            data: { functionName: "range", constraint: `count must be a non-negative integer <= 1000000, got ${v}` },
+            data: {
+              functionName: "range",
+              constraint: `count must be a non-negative integer <= 1000000, got ${v}`,
+            },
           });
         }
         start = 0;
@@ -194,14 +197,27 @@ export class FunctionsManager extends BaseManager<
         }
         const sv = args[0].value as number;
         const ev = args[1].value as number;
-        if (sv !== Math.trunc(sv) || ev !== Math.trunc(ev) || Number.isNaN(sv) || Number.isNaN(ev) || !Number.isFinite(sv) || !Number.isFinite(ev)) {
+        if (
+          sv !== Math.trunc(sv) ||
+          ev !== Math.trunc(ev) ||
+          Number.isNaN(sv) ||
+          Number.isNaN(ev) ||
+          !Number.isFinite(sv) ||
+          !Number.isFinite(ev)
+        ) {
           throw new InterpreterError(FunctionsErrorCode.ARGUMENT_OUT_OF_RANGE, {
-            data: { functionName: "range", constraint: `arguments must be integers, got ${sv} and ${ev}` },
+            data: {
+              functionName: "range",
+              constraint: `arguments must be integers, got ${sv} and ${ev}`,
+            },
           });
         }
         if (ev - sv > 1e6) {
           throw new InterpreterError(FunctionsErrorCode.ARGUMENT_OUT_OF_RANGE, {
-            data: { functionName: "range", constraint: `size exceeds limit (1000000), got ${ev - sv}` },
+            data: {
+              functionName: "range",
+              constraint: `size exceeds limit (1000000), got ${ev - sv}`,
+            },
           });
         }
         start = sv;

--- a/src/interpreter/errors/codes/interpreter.ts
+++ b/src/interpreter/errors/codes/interpreter.ts
@@ -37,6 +37,9 @@ export enum InterpreterErrorCode {
   MAX_ITERATIONS_EXCEEDED = "INT_MAX_ITERATIONS_EXCEEDED",
   WHILE_CONDITION_NOT_BOOLEAN = "INT_WHILE_CONDITION_NOT_BOOLEAN",
   IF_CONDITION_NOT_BOOLEAN = "INT_IF_CONDITION_NOT_BOOLEAN",
+  FOR_EACH_NOT_LIST = "INT_FOR_EACH_NOT_LIST",
+  FOR_EACH_VARIABLE_SHADOW = "INT_FOR_EACH_VARIABLE_SHADOW",
+  FOR_EACH_DUPLICATE_VARS = "INT_FOR_EACH_DUPLICATE_VARS",
 
   // Unknown error
   UNKNOWN_ERROR = "INT_UNKNOWN_ERROR",
@@ -127,5 +130,14 @@ export interface InterpreterErrorData {
   [InterpreterErrorCode.MAX_ITERATIONS_EXCEEDED]: Record<string, never>;
   [InterpreterErrorCode.WHILE_CONDITION_NOT_BOOLEAN]: Record<string, never>;
   [InterpreterErrorCode.IF_CONDITION_NOT_BOOLEAN]: Record<string, never>;
+  [InterpreterErrorCode.FOR_EACH_NOT_LIST]: {
+    actualType: string;
+  };
+  [InterpreterErrorCode.FOR_EACH_VARIABLE_SHADOW]: {
+    name: string;
+  };
+  [InterpreterErrorCode.FOR_EACH_DUPLICATE_VARS]: {
+    name: string;
+  };
   [InterpreterErrorCode.UNKNOWN_ERROR]: Record<string, never>;
 }

--- a/src/interpreter/errors/messages/en.ts
+++ b/src/interpreter/errors/messages/en.ts
@@ -117,6 +117,15 @@ export const messages: MessageMap = {
 
   [InterpreterErrorCode.IF_CONDITION_NOT_BOOLEAN]: "If/elif condition must be a boolean.",
 
+  [InterpreterErrorCode.FOR_EACH_NOT_LIST]: (data) =>
+    `for...in requires a List, got ${data.actualType}.`,
+
+  [InterpreterErrorCode.FOR_EACH_VARIABLE_SHADOW]: (data) =>
+    `for...in variable '${data.name}' shadows an existing variable in this scope.`,
+
+  [InterpreterErrorCode.FOR_EACH_DUPLICATE_VARS]: (data) =>
+    `for...in item and index variables must have different names, both are '${data.name}'.`,
+
   [InterpreterErrorCode.UNKNOWN_ERROR]: "An unknown error occurred during interpretation.",
 
   // Operations errors

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -11,6 +11,7 @@ import {
   type BinOpNode,
   type BooleanNode,
   type ElementWithUnitNode,
+  type ForEachNode,
   FunctionCallNode,
   type HexColorNode,
   IdentifierNode,
@@ -26,7 +27,6 @@ import {
   type StringNode,
   type UnaryOpNode,
   type WhileNode,
-  type ForEachNode,
 } from "./ast";
 import { Config } from "./config/config";
 import { InterpreterError, InterpreterErrorCode } from "./errors";

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -26,6 +26,7 @@ import {
   type StringNode,
   type UnaryOpNode,
   type WhileNode,
+  type ForEachNode,
 } from "./ast";
 import { Config } from "./config/config";
 import { InterpreterError, InterpreterErrorCode } from "./errors";
@@ -526,6 +527,79 @@ export class Interpreter {
 
       this.visit(node.body);
     }
+  }
+
+  private visitForEachNode(node: ForEachNode): ISymbolType {
+    // ADR-005: check for shadowing — loop variables must not shadow existing variables
+    if (this.symbolTable.isDefined(node.itemVar)) {
+      throw new InterpreterError(InterpreterErrorCode.FOR_EACH_VARIABLE_SHADOW, {
+        token: node.token,
+        data: { name: node.itemVar },
+      });
+    }
+    if (node.indexVar !== null) {
+      if (node.indexVar === node.itemVar) {
+        throw new InterpreterError(InterpreterErrorCode.FOR_EACH_DUPLICATE_VARS, {
+          token: node.token,
+          data: { name: node.itemVar },
+        });
+      }
+      if (this.symbolTable.isDefined(node.indexVar)) {
+        throw new InterpreterError(InterpreterErrorCode.FOR_EACH_VARIABLE_SHADOW, {
+          token: node.token,
+          data: { name: node.indexVar },
+        });
+      }
+    }
+
+    // Evaluate collection
+    const collectionVal = this.visit(node.collection);
+    if (!(collectionVal instanceof ListSymbol)) {
+      throw new InterpreterError(InterpreterErrorCode.FOR_EACH_NOT_LIST, {
+        token: node.token,
+        data: { actualType: collectionVal?.type ?? "null" },
+      });
+    }
+
+    const elements = collectionVal.value as ISymbolType[];
+    const results: ISymbolType[] = [];
+
+    for (let idx = 0; idx < elements.length; idx++) {
+      const item = elements[idx];
+
+      // Bind loop variables
+      this.symbolTable.set(node.itemVar, item);
+      if (node.indexVar !== null) {
+        this.symbolTable.set(node.indexVar, new NumberSymbol(idx, this.config));
+      }
+
+      // Execute body
+      let bodyResult: ISymbolType | null = null;
+      try {
+        bodyResult = this.visit(node.body);
+      } catch (e) {
+        // Catch ReturnSignal — propagate it out after cleanup
+        if (e instanceof ReturnSignal) {
+          // Clean up loop variables
+          this.symbolTable.delete(node.itemVar);
+          if (node.indexVar !== null) {
+            this.symbolTable.delete(node.indexVar);
+          }
+          throw e;
+        }
+        throw e;
+      }
+
+      results.push(bodyResult ?? new NullSymbol(this.config));
+    }
+
+    // Clean up loop variables — they should not leak to outer scope
+    this.symbolTable.delete(node.itemVar);
+    if (node.indexVar !== null) {
+      this.symbolTable.delete(node.indexVar);
+    }
+
+    return new ListSymbol(results, false, this.config);
   }
 
   private visitIfNode(node: IfNode): ISymbolType | null {

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -417,10 +417,7 @@ export class Parser {
     }
     this.eat(this.currentToken.type);
 
-    // Parse collection expression (e.g., range(3), myList, (1, 2, 3)).
-    // Note: [...] is always a block in TokenScript, not a list literal.
-    // Lists are created via comma separation: 1, 2, 3
-    // So the collection must be a function call, variable, or parenthesized list.
+    // Parse collection expression (e.g., [1, 2, 3], range(3), myList).
     const collection = this.expr();
 
     // Parse body block
@@ -474,6 +471,25 @@ export class Parser {
     const statements = this.statementsList() as StatementListNode;
     this.eat(TokenType.RBLOCK);
     return new BlockNode(statements);
+  }
+
+  // Explicit list literal: [expr, expr, ...]
+  private explicitList(): ListNode {
+    const token = this.currentToken;
+    this.eat(TokenType.LBLOCK);
+
+    const elements: ASTNode[] = [];
+
+    if (this.currentToken.type !== TokenType.RBLOCK) {
+      elements.push(this.expr());
+      while (this.currentToken.type === TokenType.COMMA) {
+        this.eat(TokenType.COMMA);
+        elements.push(this.expr());
+      }
+    }
+
+    this.eat(TokenType.RBLOCK);
+    return new ListNode(elements, token);
   }
 
   // implicit_list_expr : factor ((COMMA) factor)*
@@ -604,6 +620,11 @@ export class Parser {
   //        | HEX_COLOR
   private factor(): ASTNode {
     const token = this.currentToken;
+
+    // Explicit list literal: [expr, expr, ...]
+    if (token.type === TokenType.LBLOCK) {
+      return this.explicitList();
+    }
 
     // Handle unary operators
     if (

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -6,6 +6,7 @@ import {
   BlockNode,
   BooleanNode,
   ElementWithUnitNode,
+  ForEachNode,
   FunctionCallNode,
   HexColorNode,
   IdentifierNode,
@@ -23,7 +24,6 @@ import {
   TypeDeclNode,
   UnaryOpNode,
   WhileNode,
-  ForEachNode,
 } from "./ast";
 import { ParserError, ParserErrorCode } from "./errors";
 import { Lexer } from "./lexer";
@@ -428,7 +428,13 @@ export class Parser {
       this.eat(TokenType.SEMICOLON);
     }
 
-    return new ForEachNode(firstVar, indexVar, collection, body.statements as StatementListNode, forToken);
+    return new ForEachNode(
+      firstVar,
+      indexVar,
+      collection,
+      body.statements as StatementListNode,
+      forToken,
+    );
   }
 
   private ifStatement(): IfNode {

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -23,6 +23,7 @@ import {
   TypeDeclNode,
   UnaryOpNode,
   WhileNode,
+  ForEachNode,
 } from "./ast";
 import { ParserError, ParserErrorCode } from "./errors";
 import { Lexer } from "./lexer";
@@ -241,6 +242,8 @@ export class Parser {
           return this.returnStatement();
         case ReservedKeyword.WHILE:
           return this.whileStatement();
+        case ReservedKeyword.FOR:
+          return this.forStatement();
         case ReservedKeyword.IF:
           return this.ifStatement();
         case ReservedKeyword.VARIABLE:
@@ -376,6 +379,59 @@ export class Parser {
     this.eat(TokenType.RPAREN);
     const body = this.block();
     return new WhileNode(condition, body.statements as StatementListNode, whileToken);
+  }
+
+  private forStatement(): ForEachNode {
+    const forToken = this.eat(TokenType.RESERVED_KEYWORD); // 'for'
+
+    // First identifier: item variable
+    if (!this.isIdentifierToken()) {
+      throw new ParserError(ParserErrorCode.EXPECTED_TOKEN_TYPE, {
+        token: this.currentToken,
+        data: { expectedType: "identifier", actualType: this.currentToken.type },
+      });
+    }
+    const firstVar = this.currentToken.value as string;
+    this.eat(this.currentToken.type);
+
+    // Check for comma → item, index
+    let indexVar: string | null = null;
+    if (this.currentToken.type === TokenType.COMMA) {
+      this.eat(TokenType.COMMA);
+      if (!this.isIdentifierToken()) {
+        throw new ParserError(ParserErrorCode.EXPECTED_TOKEN_TYPE, {
+          token: this.currentToken,
+          data: { expectedType: "identifier", actualType: this.currentToken.type },
+        });
+      }
+      indexVar = this.currentToken.value as string;
+      this.eat(this.currentToken.type);
+    }
+
+    // Expect contextual 'in' — parsed as STRING token with value "in"
+    if (!this.isIdentifierToken() || this.currentToken.value !== "in") {
+      throw new ParserError(ParserErrorCode.EXPECTED_TOKEN_TYPE, {
+        token: this.currentToken,
+        data: { expectedType: "'in'", actualType: this.currentToken.value },
+      });
+    }
+    this.eat(this.currentToken.type);
+
+    // Parse collection expression (e.g., range(3), myList, (1, 2, 3)).
+    // Note: [...] is always a block in TokenScript, not a list literal.
+    // Lists are created via comma separation: 1, 2, 3
+    // So the collection must be a function call, variable, or parenthesized list.
+    const collection = this.expr();
+
+    // Parse body block
+    const body = this.block();
+
+    // Consume optional trailing semicolon
+    if (this.currentToken.type === TokenType.SEMICOLON) {
+      this.eat(TokenType.SEMICOLON);
+    }
+
+    return new ForEachNode(firstVar, indexVar, collection, body.statements as StatementListNode, forToken);
   }
 
   private ifStatement(): IfNode {

--- a/src/interpreter/symbolTable.ts
+++ b/src/interpreter/symbolTable.ts
@@ -18,6 +18,10 @@ export class SymbolTable {
     return !!this.symbols[name.toLowerCase()];
   }
 
+  delete(name: string): void {
+    delete this.symbols[name.toLowerCase()];
+  }
+
   reset(): void {
     this.symbols = {};
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export enum ReservedKeyword {
   ELIF = "elif",
   RETURN = "return",
   VARIABLE = "variable",
+  FOR = "for",
 }
 
 export enum TokenType {

--- a/tests/interpreter/syntax/for-in.test.ts
+++ b/tests/interpreter/syntax/for-in.test.ts
@@ -15,6 +15,12 @@ describe("for...in loop", () => {
       expect(result?.toString()).toBe("0, 10, 20");
     });
 
+    it("should iterate over a list literal", () => {
+      const interpreter = createInterpreter(`for x in [1, 2, 3] [x * 10;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("10, 20, 30");
+    });
+
     it("should handle single element list", () => {
       const interpreter = createInterpreter(`for x in range(1) [x + 42;]`);
       const result = interpreter.interpret();
@@ -212,5 +218,57 @@ describe("range() builtin", () => {
       const result = interpreter.interpret();
       expect(result?.toString()).toBe("1, 4, 9");
     });
+  });
+});
+
+describe("list literal [a, b, c]", () => {
+  it("should create a list from explicit bracket syntax", () => {
+    const interpreter = createInterpreter(`[1, 2, 3]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("1, 2, 3");
+  });
+
+  it("should create an empty list", () => {
+    const interpreter = createInterpreter(`[]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("");
+  });
+
+  it("should create a single-element list", () => {
+    const interpreter = createInterpreter(`[42]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("42");
+  });
+
+  it("should support expressions inside list literal", () => {
+    const interpreter = createInterpreter(`[1 + 2, 3 * 4, 10 - 5]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("3, 12, 5");
+  });
+
+  it("should work with nested list literals", () => {
+    const interpreter = createInterpreter(`[[1, 2], [3, 4]]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("1, 2, 3, 4");
+  });
+
+  it("should be assignable to a variable", () => {
+    const result = interpretAndGetVariable(
+      `variable items: List = [1, 2, 3];`,
+      "items",
+    );
+    expect(result?.toString()).toBe("1, 2, 3");
+  });
+
+  it("should work as for...in collection", () => {
+    const interpreter = createInterpreter(`for x in [10, 20, 30] [x + 1;]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("11, 21, 31");
+  });
+
+  it("should not break existing block syntax in if/while", () => {
+    const interpreter = createInterpreter(`if (true) [42;]`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("42");
   });
 });

--- a/tests/interpreter/syntax/for-in.test.ts
+++ b/tests/interpreter/syntax/for-in.test.ts
@@ -1,0 +1,216 @@
+import { InterpreterError } from "@interpreter/errors";
+import {
+  createInterpreter,
+  interpretAndGetVariable,
+  interpretDirect,
+  interpretExpectError,
+} from "@tests/interpreter/test-helpers";
+import { describe, expect, it } from "vitest";
+
+describe("for...in loop", () => {
+  describe("basic iteration", () => {
+    it("should iterate over a list and auto-collect results", () => {
+      const interpreter = createInterpreter(`for x in range(3) [x * 10;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("0, 10, 20");
+    });
+
+    it("should handle single element list", () => {
+      const interpreter = createInterpreter(`for x in range(1) [x + 42;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("42");
+    });
+
+    it("should handle empty list", () => {
+      const interpreter = createInterpreter(`for x in range(0) [x;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("");
+    });
+
+    it("should collect last expression per iteration", () => {
+      const interpreter = createInterpreter(`
+        for x in range(1, 2) [
+          variable y: Number = x + 1;
+          y * 2;
+        ]
+      `);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("4");
+    });
+  });
+
+  describe("index variable", () => {
+    it("should support item, index destructuring", () => {
+      const interpreter = createInterpreter(`for val, idx in range(3) [idx;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("0, 1, 2");
+    });
+
+    it("should bind correct item and index", () => {
+      const interpreter = createInterpreter(`for val, idx in range(1, 3) [val + idx;]`);
+      const result = interpreter.interpret();
+      // range(1,3) = [1, 2], indices = [0, 1]
+      // val+idx: 1+0=1, 2+1=3
+      expect(result?.toString()).toBe("1, 3");
+    });
+  });
+
+  describe("scoping", () => {
+    it("should not leak item variable to outer scope", () => {
+      const result = interpretAndGetVariable(
+        `
+        variable before: Number = 99;
+        for x in range(3) [x;];
+        `,
+        "x",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should error when item variable shadows outer variable (ADR-005)", () => {
+      expect(() =>
+        interpretExpectError(`
+          variable i: Number = 42;
+          for i in range(3) [i * 10;];
+        `),
+      ).toThrow(InterpreterError);
+    });
+
+    it("should error when index variable shadows outer variable", () => {
+      expect(() =>
+        interpretExpectError(`
+          variable idx: Number = 99;
+          for x, idx in range(2) [x;];
+        `),
+      ).toThrow(InterpreterError);
+    });
+
+    it("should error when item and index have the same name", () => {
+      expect(() =>
+        interpretExpectError(`for x, x in range(2) [x;]`),
+      ).toThrow(InterpreterError);
+    });
+
+    it("should allow reassigning outer variables from for body", () => {
+      const result = interpretAndGetVariable(
+        `
+        variable sum: Number = 0;
+        for x in range(1, 4) [sum = sum + x;];
+        `,
+        "sum",
+      );
+      expect(result?.value).toBe(6);
+    });
+  });
+
+  describe("return inside for body", () => {
+    it("should propagate return out of the loop", () => {
+      const interpreter = createInterpreter(`for x in range(3) [return 42;]`);
+      const result = interpreter.interpret();
+      expect(result?.value).toBe(42);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should error when collection is not a list (number)", () => {
+      expect(() =>
+        interpretExpectError(`for x in 42 [x;]`),
+      ).toThrow(InterpreterError);
+    });
+
+    it("should error when collection is a string", () => {
+      expect(() =>
+        interpretExpectError(`for c in "hello" [c;]`),
+      ).toThrow(InterpreterError);
+    });
+  });
+
+  describe("nested for...in", () => {
+    it("should handle nested loops with different variable names", () => {
+      // Outer iterates over range, inner doubles
+      const interpreter = createInterpreter(`
+        variable result: Number = 0;
+        for i in range(3) [
+          for j in range(2) [
+            result = result + 1;
+          ];
+        ];
+      `);
+      interpreter.interpret();
+      // 3 outer × 2 inner = 6 increments
+      const result = (interpreter as any).symbolTable.get("result");
+      expect(result?.value).toBe(6);
+    });
+  });
+
+  describe("contextual 'in' keyword", () => {
+    it("should not break CSS inches unit", () => {
+      const result = interpretDirect(`2in + 3in`);
+      expect(result).toBe("5in");
+    });
+  });
+});
+
+describe("range() builtin", () => {
+  it("range(count) should generate [0..count-1]", () => {
+    const interpreter = createInterpreter(`range(3)`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("0, 1, 2");
+  });
+
+  it("range(start, end) should generate [start..end-1]", () => {
+    const interpreter = createInterpreter(`range(2, 5)`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("2, 3, 4");
+  });
+
+  it("range(0) should return empty list", () => {
+    const interpreter = createInterpreter(`range(0)`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("");
+  });
+
+  it("range(start, start) should return empty list", () => {
+    const interpreter = createInterpreter(`range(3, 3)`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("");
+  });
+
+  it("range(5, 2) should return empty list (no reverse)", () => {
+    const interpreter = createInterpreter(`range(5, 2)`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("");
+  });
+
+  it("range(-5, -2) should work with negative numbers", () => {
+    const interpreter = createInterpreter(`range(-5, -2)`);
+    const result = interpreter.interpret();
+    expect(result?.toString()).toBe("-5, -4, -3");
+  });
+
+  it("range(-1) should error (negative count)", () => {
+    expect(() =>
+      interpretExpectError(`range(-1)`),
+    ).toThrow();
+  });
+
+  it("range(1.5) should error (non-integer)", () => {
+    expect(() =>
+      interpretExpectError(`range(1.5)`),
+    ).toThrow();
+  });
+
+  describe("for...in + range integration", () => {
+    it("should work together: for i in range(3) [i * 10;]", () => {
+      const interpreter = createInterpreter(`for i in range(3) [i * 10;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("0, 10, 20");
+    });
+
+    it("should work with range(start, end)", () => {
+      const interpreter = createInterpreter(`for i in range(1, 4) [i * i;]`);
+      const result = interpreter.interpret();
+      expect(result?.toString()).toBe("1, 4, 9");
+    });
+  });
+});

--- a/tests/interpreter/syntax/for-in.test.ts
+++ b/tests/interpreter/syntax/for-in.test.ts
@@ -1,10 +1,5 @@
 import { InterpreterError } from "@interpreter/errors";
-import {
-  createInterpreter,
-  interpretAndGetVariable,
-  interpretDirect,
-  interpretExpectError,
-} from "@tests/interpreter/test-helpers";
+import { createInterpreter, interpretAndGetVariable, interpretDirect, interpretExpectError } from "@tests/interpreter/test-helpers";
 import { describe, expect, it } from "vitest";
 
 describe("for...in loop", () => {
@@ -92,9 +87,7 @@ describe("for...in loop", () => {
     });
 
     it("should error when item and index have the same name", () => {
-      expect(() =>
-        interpretExpectError(`for x, x in range(2) [x;]`),
-      ).toThrow(InterpreterError);
+      expect(() => interpretExpectError(`for x, x in range(2) [x;]`)).toThrow(InterpreterError);
     });
 
     it("should allow reassigning outer variables from for body", () => {
@@ -119,15 +112,11 @@ describe("for...in loop", () => {
 
   describe("error cases", () => {
     it("should error when collection is not a list (number)", () => {
-      expect(() =>
-        interpretExpectError(`for x in 42 [x;]`),
-      ).toThrow(InterpreterError);
+      expect(() => interpretExpectError(`for x in 42 [x;]`)).toThrow(InterpreterError);
     });
 
     it("should error when collection is a string", () => {
-      expect(() =>
-        interpretExpectError(`for c in "hello" [c;]`),
-      ).toThrow(InterpreterError);
+      expect(() => interpretExpectError(`for c in "hello" [c;]`)).toThrow(InterpreterError);
     });
   });
 
@@ -195,15 +184,11 @@ describe("range() builtin", () => {
   });
 
   it("range(-1) should error (negative count)", () => {
-    expect(() =>
-      interpretExpectError(`range(-1)`),
-    ).toThrow();
+    expect(() => interpretExpectError(`range(-1)`)).toThrow();
   });
 
   it("range(1.5) should error (non-integer)", () => {
-    expect(() =>
-      interpretExpectError(`range(1.5)`),
-    ).toThrow();
+    expect(() => interpretExpectError(`range(1.5)`)).toThrow();
   });
 
   describe("for...in + range integration", () => {
@@ -253,10 +238,7 @@ describe("list literal [a, b, c]", () => {
   });
 
   it("should be assignable to a variable", () => {
-    const result = interpretAndGetVariable(
-      `variable items: List = [1, 2, 3];`,
-      "items",
-    );
+    const result = interpretAndGetVariable(`variable items: List = [1, 2, 3];`, "items");
     expect(result?.toString()).toBe("1, 2, 3");
   });
 

--- a/tests/lib/eval.test.ts
+++ b/tests/lib/eval.test.ts
@@ -64,7 +64,6 @@ describe("evaluateExpression", () => {
     }
   });
 
-
   it("should disallow statements by default", () => {
     const result = evaluateExpression("variable x = 5; x + 1");
     expect(result.success).toBe(false);

--- a/tests/lib/eval.test.ts
+++ b/tests/lib/eval.test.ts
@@ -64,10 +64,6 @@ describe("evaluateExpression", () => {
     }
   });
 
-  it("should handle error on unsupported syntax", () => {
-    const result = evaluateExpression("[1, 2, 3]");
-    expect(result.success).toBe(false);
-  });
 
   it("should disallow statements by default", () => {
     const result = evaluateExpression("variable x = 5; x + 1");


### PR DESCRIPTION
## Added

- **`for...in` loop with auto-collect** — iterate over lists and collect each iteration's result into a new list: `for x in [1, 2, 3] [x * 10;]` → `10, 20, 30`
- **Index variable support** — optional second binding: `for val, idx in list [val + idx;]`
- **`range()` builtin** — `range(count)` and `range(start, end)` for generating integer sequences
- **Explicit list literal syntax `[a, b, c]`** — bracket-delimited list expressions, matching Go interpreter parity
- **Loop variable scoping** — item/index variables are cleaned up after the loop; shadowing outer variables is an error (ADR-005)
- **`return` propagation in loop body** — `return` inside a `for...in` body exits the entire expression