### PR TITLE
feat: migrate config validation from arktype to @tokens-studio/schema-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Config validation now uses `@tokens-studio/schema-validation`** — the cross-language shared validator replaces the hand-rolled arktype schemas across all five kind managers (token, color, functions, unit, constants). The same parser shape is enforced in lockstep by the Go and Ruby implementations of the library.
+- **Stricter nested-shape validation** — unknown fields on `Property`, `Schema`, `ItemsSpec`, `ScriptBlock`, `Initializer`, and `Conversion` are rejected at parse time, catching field-name typos. Top-level spec fields remain tolerant for forward compatibility with plugin metadata.
+
+### Removed
+
+- **`arktype` dependency** — dropped as a direct dependency.
+
 ## [0.31.0] - 2026-03-26
 
 ## [0.31.0] - 2026-03-26

--- a/examples/web-repl/src/utils/presets.ts
+++ b/examples/web-repl/src/utils/presets.ts
@@ -71,18 +71,6 @@ return relative_darken(yellow, 10);`,
     ],
   },
   {
-    name: "Demo 6: HSL Ramp Function",
-    type: "code",
-    code: `variable yellow: Color = #FF9900;
-variable config: Dictionary;
-config.set("steps", 10);
-
-return hsl_ramp(yellow, config).values();`,
-    dependencies: [
-      "https://schema.tokenscript.dev.gcp.tokens.studio/api/v1/schema/hsl-ramp/0.1.0/",
-    ],
-  },
-  {
     name: "Demo 7: OKLCH Color Ramp",
     type: "code",
     code: `variable yellow: Color = #FF9900;
@@ -232,17 +220,6 @@ spacing.set("xl", base * 3);
 spacing.set("xxl", base * 4);
 
 return spacing;`,
-  },
-  {
-    name: "Rainbow Color Scale",
-    type: "code",
-    code: `variable config: Dictionary;
-config.set("steps", 10);
-config.set("saturation", 255);
-rainbow_color_scale(config).values();`,
-    dependencies: [
-      "https://schema.tokenscript.dev.gcp.tokens.studio/api/v1/schema/test-color-scale-rainbow/0.1.0/",
-    ],
   },
   {
     name: "Contrasting Text Color Finder",

--- a/examples/web-repl/tests/e2e/presets.spec.ts
+++ b/examples/web-repl/tests/e2e/presets.spec.ts
@@ -6,7 +6,6 @@ const TOKENSCRIPT_PRESETS = [
   "Demo 3: HSL Color Variable",
   "Demo 4: Color Ramp Loop",
   "Demo 5: Relative Darken Function",
-  "Demo 6: HSL Ramp Function",
   "Demo 7: OKLCH Color Ramp",
   "Demo 8: Ramp to Hex Values",
   "Demo 9: Mixed Unit Addition",
@@ -16,7 +15,6 @@ const TOKENSCRIPT_PRESETS = [
   "Responsive Font Size (remap)",
   "Opacity from Percentage (remap)",
   "Unit Spacing system",
-  "Rainbow Color Scale",
   "Contrasting Text Color Finder",
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.31.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@tokens-studio/schema-validation": "file:../../studio/studio-on-rails/tokenscript/schema-validation/ts",
+        "@tokens-studio/schema-validation": "^0.1.0",
         "commander": "^14.0.1",
         "readline-sync": "^1.4.10",
         "yauzl": "^3.2.0"
@@ -37,11 +37,12 @@
     "../../studio/studio-on-rails/tokenscript/schema-validation/ts": {
       "name": "@tokens-studio/schema-validation",
       "version": "0.1.0",
+      "extraneous": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "zod": "^4.1.13"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.2.4",
         "@types/node": "^22.18.6",
         "@vitest/coverage-v8": "^3.2.4",
         "tsup": "^8.5.0",
@@ -1125,8 +1126,13 @@
       "license": "MIT"
     },
     "node_modules/@tokens-studio/schema-validation": {
-      "resolved": "../../studio/studio-on-rails/tokenscript/schema-validation/ts",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@tokens-studio/schema-validation/-/schema-validation-0.1.0.tgz",
+      "integrity": "sha512-dK9U/rxXpEHVzFQb2oxaIA6mPhC/Q4EkSYe7kCy49ncw0At+zbkpUOMbSJF/SqIBtXyR6dze4qbYPB3k1bsvBQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "zod": "^4.1.13"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3040,6 +3046,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.31.0",
       "license": "MPL-2.0",
       "dependencies": {
+        "@tokens-studio/schema-validation": "file:../../studio/studio-on-rails/tokenscript/schema-validation/ts",
         "arktype": "^2.1.25",
         "commander": "^14.0.1",
         "readline-sync": "^1.4.10",
@@ -32,6 +33,21 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "../../studio/studio-on-rails/tokenscript/schema-validation/ts": {
+      "name": "@tokens-studio/schema-validation",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^4.1.13"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.2.4",
+        "@types/node": "^22.18.6",
+        "@vitest/coverage-v8": "^3.2.4",
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.2",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@ark/schema": {
@@ -1123,6 +1139,10 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tokens-studio/schema-validation": {
+      "resolved": "../../studio/studio-on-rails/tokenscript/schema-validation/ts",
+      "link": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@tokens-studio/schema-validation": "file:../../studio/studio-on-rails/tokenscript/schema-validation/ts",
-        "arktype": "^2.1.25",
         "commander": "^14.0.1",
         "readline-sync": "^1.4.10",
         "yauzl": "^3.2.0"
@@ -49,21 +48,6 @@
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       }
-    },
-    "node_modules/@ark/schema": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.53.0.tgz",
-      "integrity": "sha512-1PB7RThUiTlmIu8jbSurPrhHpVixPd4C+xNBUF/HrjIENCeDcAMg36n5mpMzED7OQGDVIzpfXXiMnaTiutjHJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ark/util": "0.53.0"
-      }
-    },
-    "node_modules/@ark/util": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.53.0.tgz",
-      "integrity": "sha512-TGn4gLlA6dJcQiqrtCtd88JhGb2XBHo6qIejsDre+nxpGuUVW4G3YZGVrwjNBTO0EyR+ykzIo4joHJzOj+/cpA==",
-      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -1364,26 +1348,6 @@
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/arkregex": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.2.tgz",
-      "integrity": "sha512-ttjDUICBVoXD/m8bf7eOjx8XMR6yIT2FmmW9vsN0FCcFOygEZvvIX8zK98tTdXkzi0LkRi5CmadB44jFEIyDNA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ark/util": "0.53.0"
-      }
-    },
-    "node_modules/arktype": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.1.25.tgz",
-      "integrity": "sha512-fdj10sNlUPeDRg1QUqMbzJ4Q7gutTOWOpLUNdcC4vxeVrN0G+cbDOvLbuxQOFj/NDAode1G7kwFv4yKwQvupJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ark/schema": "0.53.0",
-        "@ark/util": "0.53.0",
-        "arkregex": "0.0.2"
-      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2370,9 +2370,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "homepage": "https://github.com/tokens-studio/tokenscript-interpreter#readme",
   "dependencies": {
-    "@tokens-studio/schema-validation": "file:../../studio/studio-on-rails/tokenscript/schema-validation/ts",
+    "@tokens-studio/schema-validation": "^0.1.0",
     "commander": "^14.0.1",
     "readline-sync": "^1.4.10",
     "yauzl": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
   "homepage": "https://github.com/tokens-studio/tokenscript-interpreter#readme",
   "dependencies": {
     "@tokens-studio/schema-validation": "file:../../studio/studio-on-rails/tokenscript/schema-validation/ts",
-    "arktype": "^2.1.25",
     "commander": "^14.0.1",
     "readline-sync": "^1.4.10",
     "yauzl": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
   },
   "homepage": "https://github.com/tokens-studio/tokenscript-interpreter#readme",
   "dependencies": {
+    "@tokens-studio/schema-validation": "file:../../studio/studio-on-rails/tokenscript/schema-validation/ts",
     "arktype": "^2.1.25",
     "commander": "^14.0.1",
     "readline-sync": "^1.4.10",

--- a/src/interpreter/config/managers/color/manager.ts
+++ b/src/interpreter/config/managers/color/manager.ts
@@ -11,11 +11,11 @@ import { ensureValidAlpha, formatHex8, isTransparent } from "@interpreter/utils/
 import { Interpreter } from "@src/lib";
 import type { ISymbolType } from "@src/types";
 import { buildSchemaUri, parseVersionString } from "@src/utils/schema-uri";
-import { type } from "arktype";
+import { ZodError } from "@tokens-studio/schema-validation";
 import { BaseManager } from "../base-manager";
 import {
   type ColorSpecification,
-  ColorSpecificationSchema,
+  parseColorSpec,
   specName,
   validSchemaTypes,
 } from "./schema";
@@ -149,24 +149,18 @@ export class ColorManager extends BaseManager<ColorSpecification, ColorSymbol, C
   public register(uri: uriType, spec: ColorSpecification | string): ColorSpecification {
     let parsedSpec: ColorSpecification;
 
-    if (typeof spec === "string") {
-      const parseResult = ColorSpecificationSchema(JSON.parse(spec));
-      if (parseResult instanceof type.errors) {
-        throw new Error(
-          `Invalid color specification for URI ${uri}: ${parseResult.summary}
-
-Json:
-${spec}`,
-        );
-      }
-      parsedSpec = parseResult as ColorSpecification;
-    } else {
-      // Validate the object using the schema
-      const parseResult = ColorSpecificationSchema(spec);
-      if (parseResult instanceof type.errors) {
-        throw new Error(`Invalid color specification for URI ${uri}: ${parseResult.summary}`);
-      }
-      parsedSpec = parseResult as ColorSpecification;
+    try {
+      const input = typeof spec === "string" ? JSON.parse(spec) : spec;
+      parsedSpec = parseColorSpec(input);
+    } catch (err) {
+      const summary =
+        err instanceof ZodError
+          ? err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ")
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      const jsonSuffix = typeof spec === "string" ? `\n\nJson:\n${spec}` : "";
+      throw new Error(`Invalid color specification for URI ${uri}: ${summary}${jsonSuffix}`);
     }
 
     this.specs.set(uri, parsedSpec);

--- a/src/interpreter/config/managers/color/manager.ts
+++ b/src/interpreter/config/managers/color/manager.ts
@@ -13,12 +13,7 @@ import type { ISymbolType } from "@src/types";
 import { buildSchemaUri, parseVersionString } from "@src/utils/schema-uri";
 import { ZodError } from "@tokens-studio/schema-validation";
 import { BaseManager } from "../base-manager";
-import {
-  type ColorSpecification,
-  parseColorSpec,
-  specName,
-  validSchemaTypes,
-} from "./schema";
+import { type ColorSpecification, parseColorSpec, specName, validSchemaTypes } from "./schema";
 
 // Types -----------------------------------------------------------------------
 

--- a/src/interpreter/config/managers/color/schema.ts
+++ b/src/interpreter/config/managers/color/schema.ts
@@ -11,7 +11,7 @@
 // `MINIMAL_COLOR_SPECIFICATION`) so consumer code does not have to
 // change.
 
-import { Color } from "@tokens-studio/schema-validation";
+import { Color, type z } from "@tokens-studio/schema-validation";
 
 // Types -----------------------------------------------------------------------
 
@@ -25,6 +25,12 @@ export type ColorSpecification = Color.ColorSpecification;
 export type SpecProperty = Color.ColorProperty;
 
 // Validation API --------------------------------------------------------------
+//
+// Explicit type annotations on these re-exports are required because
+// tsup's DTS bundling (rollup-plugin-dts) can't construct a public path
+// for the internal types that transitively appear in the inferred
+// return types of `Color.parseColorSpec` etc. Without the annotation
+// the DTS emit fails with TS4023 / TS2742.
 
 /**
  * Validate and parse a JSON value as a color specification. Throws a
@@ -35,13 +41,15 @@ export type SpecProperty = Color.ColorProperty;
  *   - Nested shapes (ColorSchema, ColorProperty, Initializer, Conversion,
  *     ColorScriptBlock): unknown fields and unsupported enum values fail.
  */
-export const parseColorSpec = Color.parseColorSpec;
+export const parseColorSpec: (json: unknown) => ColorSpecification = Color.parseColorSpec;
 
 /**
  * Like `parseColorSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseColorSpec = Color.safeParseColorSpec;
+export const safeParseColorSpec: (
+	json: unknown,
+) => z.ZodSafeParseResult<ColorSpecification> = Color.safeParseColorSpec;
 
 /**
  * Historical compatibility alias for `parseColorSpec`. Wrap a call in a
@@ -49,7 +57,8 @@ export const safeParseColorSpec = Color.safeParseColorSpec;
  *
  * @deprecated Prefer `parseColorSpec` / `safeParseColorSpec`.
  */
-export const ColorSpecificationSchema = Color.parseColorSpec;
+export const ColorSpecificationSchema: (json: unknown) => ColorSpecification =
+	Color.parseColorSpec;
 
 // Constants -------------------------------------------------------------------
 
@@ -65,7 +74,7 @@ export const validSchemaTypes = ["number", "string", "color"] as const;
 // Helpers ---------------------------------------------------------------------
 
 /** Lowercased lookup name for a color spec. */
-export const specName = Color.specName;
+export const specName: (spec: ColorSpecification) => string = Color.specName;
 
 // Defaults --------------------------------------------------------------------
 

--- a/src/interpreter/config/managers/color/schema.ts
+++ b/src/interpreter/config/managers/color/schema.ts
@@ -47,9 +47,8 @@ export const parseColorSpec: (json: unknown) => ColorSpecification = Color.parse
  * Like `parseColorSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseColorSpec: (
-	json: unknown,
-) => z.ZodSafeParseResult<ColorSpecification> = Color.safeParseColorSpec;
+export const safeParseColorSpec: (json: unknown) => z.ZodSafeParseResult<ColorSpecification> =
+  Color.safeParseColorSpec;
 
 /**
  * Historical compatibility alias for `parseColorSpec`. Wrap a call in a
@@ -57,8 +56,7 @@ export const safeParseColorSpec: (
  *
  * @deprecated Prefer `parseColorSpec` / `safeParseColorSpec`.
  */
-export const ColorSpecificationSchema: (json: unknown) => ColorSpecification =
-	Color.parseColorSpec;
+export const ColorSpecificationSchema: (json: unknown) => ColorSpecification = Color.parseColorSpec;
 
 // Constants -------------------------------------------------------------------
 

--- a/src/interpreter/config/managers/color/schema.ts
+++ b/src/interpreter/config/managers/color/schema.ts
@@ -1,103 +1,80 @@
-import { type } from "arktype";
-import { isObject } from "@/src/interpreter/utils/type";
+// Color-kind schema shim.
+//
+// Re-exports the typed shapes from @tokens-studio/schema-validation so
+// that the rest of the interpreter can continue importing from
+// "@interpreter/config/managers/color/schema". The schema-validation
+// package is the cross-language source of truth for the schema language
+// (TS / Go / Ruby).
+//
+// Aliases preserve the historical interpreter names (`SpecProperty`,
+// `ColorSpecificationSchema`, `validSchemaTypes`,
+// `MINIMAL_COLOR_SPECIFICATION`) so consumer code does not have to
+// change.
 
-// Utility Schemas -------------------------------------------------------------
+import { Color } from "@tokens-studio/schema-validation";
 
-const ScriptBlockSchema = type({
-  type: "string",
-  script: "string",
-});
+// Types -----------------------------------------------------------------------
 
-// Schema ----------------------------------------------------------------------
+export type ColorSpecification = Color.ColorSpecification;
 
-const InitializerSchema = type({
-  "title?": "string",
-  keyword: "string",
-  "description?": "string",
-  // schema: type({ "...": "unknown" }),
-  script: ScriptBlockSchema,
-});
+/**
+ * A property of a color schema (typically a channel like r/g/b/a).
+ * Historical alias for the `ColorProperty` type from the
+ * schema-validation library.
+ */
+export type SpecProperty = Color.ColorProperty;
 
-const ConversionSchema = type({
-  source: "string",
-  target: "string",
-  "description?": "string",
-  lossless: "boolean",
-  script: ScriptBlockSchema,
-});
+// Validation API --------------------------------------------------------------
 
-export const validSchemaTypes = ["number", "string", "color"];
+/**
+ * Validate and parse a JSON value as a color specification. Throws a
+ * `ZodError` with a structured field-by-field error report on failure.
+ *
+ * Strictness:
+ *   - Top level: unknown fields are tolerated (silently stripped).
+ *   - Nested shapes (ColorSchema, ColorProperty, Initializer, Conversion,
+ *     ColorScriptBlock): unknown fields and unsupported enum values fail.
+ */
+export const parseColorSpec = Color.parseColorSpec;
 
-// Property type for spec schema
-export interface SpecProperty {
-  type: "number" | "string" | "color";
-}
+/**
+ * Like `parseColorSpec` but returns a `{ success, data | error }`
+ * discriminated union instead of throwing.
+ */
+export const safeParseColorSpec = Color.safeParseColorSpec;
 
-interface SpecSchemaType {
-  type: "object";
-  properties: Record<string, SpecProperty>;
-  required?: string[];
-  order?: string[];
-  additionalProperties?: boolean;
-}
+/**
+ * Historical compatibility alias for `parseColorSpec`. Wrap a call in a
+ * `try { ... } catch (err) { ... }` to handle validation failures.
+ *
+ * @deprecated Prefer `parseColorSpec` / `safeParseColorSpec`.
+ */
+export const ColorSpecificationSchema = Color.parseColorSpec;
 
-// Main ------------------------------------------------------------------------
+// Constants -------------------------------------------------------------------
 
-export interface ColorSpecification {
-  name: string;
-  type: "color";
-  description?: string;
-  schema?: SpecSchemaType;
-  initializers: Array<{
-    title?: string;
-    keyword: string;
-    description?: string;
-    script: {
-      type: string;
-      script: string;
-    };
-  }>;
-  conversions: Array<{
-    source: string;
-    target: string;
-    description?: string;
-    lossless: boolean;
-    script: {
-      type: string;
-      script: string;
-    };
-  }>;
-}
+/**
+ * The set of valid `type` values for a color schema property.
+ *
+ * Hand-spelled (rather than reading `.options` off the zod enum)
+ * because tsup's DTS bundling drops the value side of namespaced
+ * re-exports.
+ */
+export const validSchemaTypes = ["number", "string", "color"] as const;
 
-const _SpecPropertySchema = type({
-  type: "'number' | 'string' | 'color'",
-});
+// Helpers ---------------------------------------------------------------------
 
-const SpecSchemaSchema = type({
-  type: "'object'",
-  properties: type("Record<string, unknown>").narrow((v): v is Record<string, SpecProperty> => {
-    if (!isObject(v)) return false;
-    return Object.values(v).every((prop) =>
-      ["number", "string", "color"].includes((prop as any)?.type),
-    );
-  }),
-  "required?": "string[]",
-  "order?": "string[]",
-  "additionalProperties?": "boolean",
-});
+/** Lowercased lookup name for a color spec. */
+export const specName = Color.specName;
 
-export const ColorSpecificationSchema = type({
-  name: "string",
-  type: "'color'",
-  "description?": "string",
-  "schema?": SpecSchemaSchema,
-  initializers: InitializerSchema.array(),
-  conversions: ConversionSchema.array(),
-});
+// Defaults --------------------------------------------------------------------
 
-export const specName = (spec: ColorSpecification): string => spec.name.toLowerCase();
-
-// Minimal viable ColorSpecification for testing and defaults
+/**
+ * Minimal viable ColorSpecification for testing and defaults.
+ *
+ * Always passes `parseColorSpec` — see the schema-minimal regression
+ * test in tests/interpreter/color/schema-minimal.test.ts.
+ */
 export const MINIMAL_COLOR_SPECIFICATION: ColorSpecification = {
   name: "MinimalColor",
   type: "color" as const,

--- a/src/interpreter/config/managers/constants/schema.ts
+++ b/src/interpreter/config/managers/constants/schema.ts
@@ -35,14 +35,14 @@ export type ConstantsSpecification = Constants.ConstantsSpecification;
  *     array, and `null` values are rejected.
  */
 export const parseConstantsSpec: (json: unknown) => ConstantsSpecification =
-	Constants.parseConstantsSpec;
+  Constants.parseConstantsSpec;
 
 /**
  * Like `parseConstantsSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
 export const safeParseConstantsSpec: (
-	json: unknown,
+  json: unknown,
 ) => z.ZodSafeParseResult<ConstantsSpecification> = Constants.safeParseConstantsSpec;
 
 /**
@@ -52,7 +52,7 @@ export const safeParseConstantsSpec: (
  * @deprecated Prefer `parseConstantsSpec` / `safeParseConstantsSpec`.
  */
 export const ConstantsSpecificationSchema: (json: unknown) => ConstantsSpecification =
-	Constants.parseConstantsSpec;
+  Constants.parseConstantsSpec;
 
 // Helpers ---------------------------------------------------------------------
 

--- a/src/interpreter/config/managers/constants/schema.ts
+++ b/src/interpreter/config/managers/constants/schema.ts
@@ -1,17 +1,50 @@
-import { type } from "arktype";
+// Constants-kind schema shim.
+//
+// Re-exports the typed shapes from @tokens-studio/schema-validation so
+// that the rest of the interpreter can continue importing from
+// "@interpreter/config/managers/constants/schema". The schema-validation
+// package is the cross-language source of truth for the schema language
+// (TS / Go / Ruby).
+//
+// The historical alias `ConstantsSpecificationSchema` is preserved for
+// public API compatibility but is currently not called from anywhere
+// inside the interpreter (Constants are dispatched in
+// `Config.registerSchemas` without separate validation).
 
-export interface ConstantsSpecification {
-  name: string;
-  type: "constants";
-  description?: string;
-  inline: boolean;
-  values: Record<string, string | number | boolean>;
-}
+import { Constants } from "@tokens-studio/schema-validation";
 
-export const ConstantsSpecificationSchema = type({
-  name: "string",
-  type: "'constants'",
-  "description?": "string",
-  inline: "boolean",
-  values: "Record<string, string | number | boolean>",
-});
+// Types -----------------------------------------------------------------------
+
+export type ConstantsSpecification = Constants.ConstantsSpecification;
+
+// Validation API --------------------------------------------------------------
+
+/**
+ * Validate and parse a JSON value as a constants specification. Throws
+ * a `ZodError` with a structured field-by-field error report on failure.
+ *
+ * Strictness:
+ *   - Top level: unknown fields are tolerated (silently stripped).
+ *   - `values` entries: must be `string | number | boolean`. Object,
+ *     array, and `null` values are rejected.
+ */
+export const parseConstantsSpec = Constants.parseConstantsSpec;
+
+/**
+ * Like `parseConstantsSpec` but returns a `{ success, data | error }`
+ * discriminated union instead of throwing.
+ */
+export const safeParseConstantsSpec = Constants.safeParseConstantsSpec;
+
+/**
+ * Historical compatibility alias for `parseConstantsSpec`. Wrap a call
+ * in a `try { ... } catch (err) { ... }` to handle validation failures.
+ *
+ * @deprecated Prefer `parseConstantsSpec` / `safeParseConstantsSpec`.
+ */
+export const ConstantsSpecificationSchema = Constants.parseConstantsSpec;
+
+// Helpers ---------------------------------------------------------------------
+
+/** Lowercased lookup name for a constants spec. */
+export const specName = Constants.specName;

--- a/src/interpreter/config/managers/constants/schema.ts
+++ b/src/interpreter/config/managers/constants/schema.ts
@@ -11,13 +11,19 @@
 // inside the interpreter (Constants are dispatched in
 // `Config.registerSchemas` without separate validation).
 
-import { Constants } from "@tokens-studio/schema-validation";
+import { Constants, type z } from "@tokens-studio/schema-validation";
 
 // Types -----------------------------------------------------------------------
 
 export type ConstantsSpecification = Constants.ConstantsSpecification;
 
 // Validation API --------------------------------------------------------------
+//
+// Explicit type annotations on these re-exports are required because
+// tsup's DTS bundling (rollup-plugin-dts) can't construct a public path
+// for the internal types that transitively appear in the inferred
+// return types of `Constants.parseConstantsSpec` etc. Without the
+// annotation the DTS emit fails with TS4023 / TS2742.
 
 /**
  * Validate and parse a JSON value as a constants specification. Throws
@@ -28,13 +34,16 @@ export type ConstantsSpecification = Constants.ConstantsSpecification;
  *   - `values` entries: must be `string | number | boolean`. Object,
  *     array, and `null` values are rejected.
  */
-export const parseConstantsSpec = Constants.parseConstantsSpec;
+export const parseConstantsSpec: (json: unknown) => ConstantsSpecification =
+	Constants.parseConstantsSpec;
 
 /**
  * Like `parseConstantsSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseConstantsSpec = Constants.safeParseConstantsSpec;
+export const safeParseConstantsSpec: (
+	json: unknown,
+) => z.ZodSafeParseResult<ConstantsSpecification> = Constants.safeParseConstantsSpec;
 
 /**
  * Historical compatibility alias for `parseConstantsSpec`. Wrap a call
@@ -42,9 +51,10 @@ export const safeParseConstantsSpec = Constants.safeParseConstantsSpec;
  *
  * @deprecated Prefer `parseConstantsSpec` / `safeParseConstantsSpec`.
  */
-export const ConstantsSpecificationSchema = Constants.parseConstantsSpec;
+export const ConstantsSpecificationSchema: (json: unknown) => ConstantsSpecification =
+	Constants.parseConstantsSpec;
 
 // Helpers ---------------------------------------------------------------------
 
 /** Lowercased lookup name for a constants spec. */
-export const specName = Constants.specName;
+export const specName: (spec: ConstantsSpecification) => string = Constants.specName;

--- a/src/interpreter/config/managers/functions/manager.ts
+++ b/src/interpreter/config/managers/functions/manager.ts
@@ -9,12 +9,12 @@ import { Lexer } from "@interpreter/lexer";
 import { Parser } from "@interpreter/parser";
 import { BooleanSymbol, ListSymbol, NumberSymbol, StringSymbol } from "@interpreter/symbols";
 import type { ISymbolType, Token } from "@src/types";
-import { type } from "arktype";
+import { ZodError } from "@tokens-studio/schema-validation";
 import { BaseManager } from "../base-manager";
 
 import { createSumFunction, mathFunctions } from "./builtin/math";
 
-import { type FunctionSpecification, FunctionSpecificationSchema } from "./schema";
+import { type FunctionSpecification, parseFunctionSpec } from "./schema";
 
 type functionName = string;
 type FunctionImpl = (...args: ISymbolType[]) => ISymbolType;
@@ -47,18 +47,17 @@ export class FunctionsManager extends BaseManager<
   public register(name: functionName, spec: FunctionSpecification | string): FunctionSpecification {
     let parsedSpec: FunctionSpecification;
 
-    if (typeof spec === "string") {
-      const parseResult = FunctionSpecificationSchema(JSON.parse(spec));
-      if (parseResult instanceof type.errors) {
-        throw new Error(`Invalid function specification for ${name}: ${parseResult.summary}`);
-      }
-      parsedSpec = parseResult as FunctionSpecification;
-    } else {
-      const parseResult = FunctionSpecificationSchema(spec);
-      if (parseResult instanceof type.errors) {
-        throw new Error(`Invalid function specification for ${name}: ${parseResult.summary}`);
-      }
-      parsedSpec = parseResult as FunctionSpecification;
+    try {
+      const input = typeof spec === "string" ? JSON.parse(spec) : spec;
+      parsedSpec = parseFunctionSpec(input);
+    } catch (err) {
+      const summary =
+        err instanceof ZodError
+          ? err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ")
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      throw new Error(`Invalid function specification for ${name}: ${summary}`);
     }
 
     const functionName = parsedSpec.keyword.toLowerCase();

--- a/src/interpreter/config/managers/functions/schema.ts
+++ b/src/interpreter/config/managers/functions/schema.ts
@@ -1,33 +1,48 @@
-import { type } from "arktype";
+// Function-kind schema shim.
+//
+// Re-exports the typed shapes from @tokens-studio/schema-validation so
+// that the rest of the interpreter can continue importing from
+// "@interpreter/config/managers/functions/schema". The schema-validation
+// package is the cross-language source of truth for the schema language
+// (TS / Go / Ruby).
+//
+// The historical alias `FunctionSpecificationSchema` is preserved for
+// consumer code that still uses the callable form.
 
-export const FunctionSpecificationSchema = type({
-  name: "string",
-  type: "'function'",
-  "input?": {
-    type: "'object'",
-    "properties?": "Record<string, unknown>",
-  },
-  script: {
-    type: "string",
-    script: "string",
-  },
-  keyword: "string",
-  "description?": "string",
-  "requirements?": "string[]",
-});
+import { Fn } from "@tokens-studio/schema-validation";
 
-export interface FunctionSpecification {
-  name: string;
-  type: "function";
-  input?: {
-    type: "object";
-    properties?: Record<string, unknown>;
-  };
-  script: {
-    type: string;
-    script: string;
-  };
-  keyword: string;
-  description?: string;
-  requirements?: string[];
-}
+// Types -----------------------------------------------------------------------
+
+export type FunctionSpecification = Fn.FunctionSpecification;
+
+// Validation API --------------------------------------------------------------
+
+/**
+ * Validate and parse a JSON value as a function specification. Throws a
+ * `ZodError` with a structured field-by-field error report on failure.
+ *
+ * Strictness:
+ *   - Top level: unknown fields are tolerated (silently stripped).
+ *   - Nested shapes (FunctionInput, FunctionScriptBlock): unknown
+ *     fields are rejected.
+ */
+export const parseFunctionSpec = Fn.parseFunctionSpec;
+
+/**
+ * Like `parseFunctionSpec` but returns a `{ success, data | error }`
+ * discriminated union instead of throwing.
+ */
+export const safeParseFunctionSpec = Fn.safeParseFunctionSpec;
+
+/**
+ * Historical compatibility alias for `parseFunctionSpec`. Wrap a call in
+ * a `try { ... } catch (err) { ... }` to handle validation failures.
+ *
+ * @deprecated Prefer `parseFunctionSpec` / `safeParseFunctionSpec`.
+ */
+export const FunctionSpecificationSchema = Fn.parseFunctionSpec;
+
+// Helpers ---------------------------------------------------------------------
+
+/** Lowercased lookup name for a function spec. */
+export const specName = Fn.specName;

--- a/src/interpreter/config/managers/functions/schema.ts
+++ b/src/interpreter/config/managers/functions/schema.ts
@@ -9,13 +9,19 @@
 // The historical alias `FunctionSpecificationSchema` is preserved for
 // consumer code that still uses the callable form.
 
-import { Fn } from "@tokens-studio/schema-validation";
+import { Fn, type z } from "@tokens-studio/schema-validation";
 
 // Types -----------------------------------------------------------------------
 
 export type FunctionSpecification = Fn.FunctionSpecification;
 
 // Validation API --------------------------------------------------------------
+//
+// Explicit type annotations on these re-exports are required because
+// tsup's DTS bundling (rollup-plugin-dts) can't construct a public path
+// for the internal types that transitively appear in the inferred
+// return types of `Fn.parseFunctionSpec` etc. Without the annotation
+// the DTS emit fails with TS4023 / TS2742.
 
 /**
  * Validate and parse a JSON value as a function specification. Throws a
@@ -26,13 +32,15 @@ export type FunctionSpecification = Fn.FunctionSpecification;
  *   - Nested shapes (FunctionInput, FunctionScriptBlock): unknown
  *     fields are rejected.
  */
-export const parseFunctionSpec = Fn.parseFunctionSpec;
+export const parseFunctionSpec: (json: unknown) => FunctionSpecification = Fn.parseFunctionSpec;
 
 /**
  * Like `parseFunctionSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseFunctionSpec = Fn.safeParseFunctionSpec;
+export const safeParseFunctionSpec: (
+	json: unknown,
+) => z.ZodSafeParseResult<FunctionSpecification> = Fn.safeParseFunctionSpec;
 
 /**
  * Historical compatibility alias for `parseFunctionSpec`. Wrap a call in
@@ -40,9 +48,10 @@ export const safeParseFunctionSpec = Fn.safeParseFunctionSpec;
  *
  * @deprecated Prefer `parseFunctionSpec` / `safeParseFunctionSpec`.
  */
-export const FunctionSpecificationSchema = Fn.parseFunctionSpec;
+export const FunctionSpecificationSchema: (json: unknown) => FunctionSpecification =
+	Fn.parseFunctionSpec;
 
 // Helpers ---------------------------------------------------------------------
 
 /** Lowercased lookup name for a function spec. */
-export const specName = Fn.specName;
+export const specName: (spec: FunctionSpecification) => string = Fn.specName;

--- a/src/interpreter/config/managers/functions/schema.ts
+++ b/src/interpreter/config/managers/functions/schema.ts
@@ -38,9 +38,8 @@ export const parseFunctionSpec: (json: unknown) => FunctionSpecification = Fn.pa
  * Like `parseFunctionSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseFunctionSpec: (
-	json: unknown,
-) => z.ZodSafeParseResult<FunctionSpecification> = Fn.safeParseFunctionSpec;
+export const safeParseFunctionSpec: (json: unknown) => z.ZodSafeParseResult<FunctionSpecification> =
+  Fn.safeParseFunctionSpec;
 
 /**
  * Historical compatibility alias for `parseFunctionSpec`. Wrap a call in
@@ -49,7 +48,7 @@ export const safeParseFunctionSpec: (
  * @deprecated Prefer `parseFunctionSpec` / `safeParseFunctionSpec`.
  */
 export const FunctionSpecificationSchema: (json: unknown) => FunctionSpecification =
-	Fn.parseFunctionSpec;
+  Fn.parseFunctionSpec;
 
 // Helpers ---------------------------------------------------------------------
 

--- a/src/interpreter/config/managers/token/manager.ts
+++ b/src/interpreter/config/managers/token/manager.ts
@@ -85,7 +85,11 @@ export class TokenManager extends BaseManager<TokenSpecification, TokenSymbol, T
       parsedSpec = parseTokenSpec(input);
     } catch (err) {
       const summary =
-        err instanceof ZodError ? err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ") : err instanceof Error ? err.message : String(err);
+        err instanceof ZodError
+          ? err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ")
+          : err instanceof Error
+            ? err.message
+            : String(err);
       const jsonSuffix = typeof spec === "string" ? `\nJson:\n${spec}` : "";
       throw new Error(`Invalid token specification for URI ${uri}: ${summary}${jsonSuffix}`);
     }

--- a/src/interpreter/config/managers/token/manager.ts
+++ b/src/interpreter/config/managers/token/manager.ts
@@ -10,14 +10,14 @@ import {
   TokenSymbol,
 } from "@interpreter/symbols";
 import type { ASTNode, ISymbolType } from "@src/types";
-import { type } from "arktype";
+import { ZodError } from "@tokens-studio/schema-validation";
 import { BaseManager } from "../base-manager";
 import {
+  parseTokenSpec,
   type SpecItemsType,
   type SpecProperty,
   specName,
   type TokenSpecification,
-  TokenSpecificationSchema,
 } from "./schema";
 
 type uriType = string;
@@ -80,22 +80,14 @@ export class TokenManager extends BaseManager<TokenSpecification, TokenSymbol, T
   public register(uri: uriType, spec: TokenSpecification | string): TokenSpecification {
     let parsedSpec: TokenSpecification;
 
-    if (typeof spec === "string") {
-      const parseResult = TokenSpecificationSchema(JSON.parse(spec));
-      if (parseResult instanceof type.errors) {
-        throw new Error(
-          `Invalid token specification for URI ${uri}: ${parseResult.summary}
-Json:
-${spec}`,
-        );
-      }
-      parsedSpec = parseResult as TokenSpecification;
-    } else {
-      const parseResult = TokenSpecificationSchema(spec);
-      if (parseResult instanceof type.errors) {
-        throw new Error(`Invalid token specification for URI ${uri}: ${parseResult.summary}`);
-      }
-      parsedSpec = parseResult as TokenSpecification;
+    try {
+      const input = typeof spec === "string" ? JSON.parse(spec) : spec;
+      parsedSpec = parseTokenSpec(input);
+    } catch (err) {
+      const summary =
+        err instanceof ZodError ? err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ") : err instanceof Error ? err.message : String(err);
+      const jsonSuffix = typeof spec === "string" ? `\nJson:\n${spec}` : "";
+      throw new Error(`Invalid token specification for URI ${uri}: ${summary}${jsonSuffix}`);
     }
 
     this.specs.set(uri, parsedSpec);

--- a/src/interpreter/config/managers/token/schema.ts
+++ b/src/interpreter/config/managers/token/schema.ts
@@ -1,66 +1,77 @@
-import { type } from "arktype";
+// Token-kind schema shim.
+//
+// Re-exports the typed shapes from @tokens-studio/schema-validation so that
+// the rest of the interpreter can continue importing from
+// "@interpreter/config/managers/token/schema". The schema-validation
+// package is the cross-language source of truth for the schema language
+// (TS / Go / Ruby).
+//
+// Aliases preserve the historical interpreter names (`SpecProperty`,
+// `SpecItemsType`, `TokenSpecificationSchema`) so consumer code does not
+// have to change.
 
-// Schema ----------------------------------------------------------------------
+import { Token, type z } from "@tokens-studio/schema-validation";
 
-export const validSchemaTypes = ["number", "string", "token", "object", "list"];
+// Types -----------------------------------------------------------------------
 
-// Property type for spec schema
-export interface SpecProperty {
-  type: "number" | "string" | "token" | "object" | "list";
-  url?: string; // For token references
-  properties?: Record<string, SpecProperty>; // For nested objects
-  validations?: Record<string, string>; // Validation scripts
-  items?: SpecItemsType; // For list types - defines the schema for each item
-}
+export type TokenSpecification = Token.TokenSpecification;
 
-// Items schema for list types
-export interface SpecItemsType {
-  type: "object" | "token";
-  url?: string; // For token references (when type is "token")
-  properties?: Record<string, SpecProperty>; // For object items
-}
+/**
+ * A property of a token's structural schema. Historical alias for the
+ * recursive `Property` type from the schema-validation library; the
+ * `z.infer` form is needed because tsup's DTS bundling drops the
+ * type side of the value+type merged export through `* as Token`.
+ */
+export type SpecProperty = z.infer<typeof Token.Property>;
 
-interface SpecSchemaType {
-  type: "object" | "number" | "string" | "list";
-  properties?: Record<string, SpecProperty>;
-  validations?: Record<string, string>;
-  required?: string[];
-  order?: string[];
-  additionalProperties?: boolean;
-  items?: SpecItemsType; // For list types
-}
+/**
+ * The shape of items inside a list-typed property/schema. Historical
+ * alias for the `ItemsSpec` type from the schema-validation library;
+ * see {@link SpecProperty} for why `z.infer` is needed.
+ */
+export type SpecItemsType = z.infer<typeof Token.ItemsSpec>;
 
-// Main ------------------------------------------------------------------------
+// Validation API --------------------------------------------------------------
 
-export interface TokenSpecification {
-  name: string;
-  type: "token";
-  description?: string;
-  url?: string;
-  schema?: SpecSchemaType;
-  /** TokenScript validation script. Receives {input} and should return true or error string. Can be a string (direct script) or object with type and script (built schema). */
-  validation?: string | { type: string; script: string };
-}
+/**
+ * Validate and parse a JSON value as a token specification. Throws a
+ * `ZodError` with a structured field-by-field error report on failure.
+ *
+ * Strictness:
+ *   - Top level: unknown fields are tolerated (silently stripped).
+ *   - Nested shapes (Schema, Property, ItemsSpec, ScriptBlock):
+ *     unknown fields and unsupported enum values fail.
+ */
+export const parseTokenSpec = Token.parseTokenSpec;
 
-// Arktype schemas for validation
+/**
+ * Like `parseTokenSpec` but returns a `{ success, data | error }`
+ * discriminated union instead of throwing.
+ */
+export const safeParseTokenSpec = Token.safeParseTokenSpec;
 
-const SpecSchemaSchema = type({
-  type: "'object' | 'number' | 'string' | 'list'",
-  "properties?": "Record<string, unknown>", // Simplified validation
-  "validations?": "Record<string, string>",
-  "required?": "string[]",
-  "order?": "string[]",
-  "additionalProperties?": "boolean",
-  "items?": "unknown", // For list types - validated at runtime
-});
+/**
+ * Historical compatibility alias for `parseTokenSpec`. Wrap a call in a
+ * `try { ... } catch (err) { ... }` to handle validation failures.
+ *
+ * @deprecated Prefer `parseTokenSpec` / `safeParseTokenSpec`.
+ */
+export const TokenSpecificationSchema = Token.parseTokenSpec;
 
-export const TokenSpecificationSchema = type({
-  name: "string",
-  type: "'token'",
-  "description?": "string",
-  "url?": "string",
-  "schema?": SpecSchemaSchema,
-  "validation?": "string | unknown", // Allow string or object, validated at runtime in manager
-});
+// Constants -------------------------------------------------------------------
 
-export const specName = (spec: TokenSpecification): string => spec.name.toLowerCase();
+/**
+ * The set of valid `type` values for a token schema.
+ *
+ * Mirrored as a plain array for use in error messages and for backwards
+ * compatibility with the previous arktype declaration. Hand-spelled
+ * (rather than reading `.options` off the zod enum) because tsup's DTS
+ * bundling drops the value side of namespaced re-exports — see
+ * {@link SpecProperty} for the same workaround.
+ */
+export const validSchemaTypes = ["number", "string", "token", "object", "list"] as const;
+
+// Helpers ---------------------------------------------------------------------
+
+/** Lowercased lookup name for a token spec. */
+export const specName = Token.specName;

--- a/src/interpreter/config/managers/token/schema.ts
+++ b/src/interpreter/config/managers/token/schema.ts
@@ -54,9 +54,8 @@ export const parseTokenSpec: (json: unknown) => TokenSpecification = Token.parse
  * Like `parseTokenSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseTokenSpec: (
-	json: unknown,
-) => z.ZodSafeParseResult<TokenSpecification> = Token.safeParseTokenSpec;
+export const safeParseTokenSpec: (json: unknown) => z.ZodSafeParseResult<TokenSpecification> =
+  Token.safeParseTokenSpec;
 
 /**
  * Historical compatibility alias for `parseTokenSpec`. Wrap a call in a
@@ -64,8 +63,7 @@ export const safeParseTokenSpec: (
  *
  * @deprecated Prefer `parseTokenSpec` / `safeParseTokenSpec`.
  */
-export const TokenSpecificationSchema: (json: unknown) => TokenSpecification =
-	Token.parseTokenSpec;
+export const TokenSpecificationSchema: (json: unknown) => TokenSpecification = Token.parseTokenSpec;
 
 // Constants -------------------------------------------------------------------
 

--- a/src/interpreter/config/managers/token/schema.ts
+++ b/src/interpreter/config/managers/token/schema.ts
@@ -32,6 +32,12 @@ export type SpecProperty = z.infer<typeof Token.Property>;
 export type SpecItemsType = z.infer<typeof Token.ItemsSpec>;
 
 // Validation API --------------------------------------------------------------
+//
+// Explicit type annotations on these re-exports are required because
+// tsup's DTS bundling (rollup-plugin-dts) can't construct a public path
+// for the internal `Property` / `ItemsSpec` / zod types that transitively
+// appear in the inferred return types of `Token.parseTokenSpec` etc.
+// Without the annotation the DTS emit fails with TS4023 / TS2742.
 
 /**
  * Validate and parse a JSON value as a token specification. Throws a
@@ -42,13 +48,15 @@ export type SpecItemsType = z.infer<typeof Token.ItemsSpec>;
  *   - Nested shapes (Schema, Property, ItemsSpec, ScriptBlock):
  *     unknown fields and unsupported enum values fail.
  */
-export const parseTokenSpec = Token.parseTokenSpec;
+export const parseTokenSpec: (json: unknown) => TokenSpecification = Token.parseTokenSpec;
 
 /**
  * Like `parseTokenSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseTokenSpec = Token.safeParseTokenSpec;
+export const safeParseTokenSpec: (
+	json: unknown,
+) => z.ZodSafeParseResult<TokenSpecification> = Token.safeParseTokenSpec;
 
 /**
  * Historical compatibility alias for `parseTokenSpec`. Wrap a call in a
@@ -56,7 +64,8 @@ export const safeParseTokenSpec = Token.safeParseTokenSpec;
  *
  * @deprecated Prefer `parseTokenSpec` / `safeParseTokenSpec`.
  */
-export const TokenSpecificationSchema = Token.parseTokenSpec;
+export const TokenSpecificationSchema: (json: unknown) => TokenSpecification =
+	Token.parseTokenSpec;
 
 // Constants -------------------------------------------------------------------
 
@@ -74,4 +83,4 @@ export const validSchemaTypes = ["number", "string", "token", "object", "list"] 
 // Helpers ---------------------------------------------------------------------
 
 /** Lowercased lookup name for a token spec. */
-export const specName = Token.specName;
+export const specName: (spec: TokenSpecification) => string = Token.specName;

--- a/src/interpreter/config/managers/unit/manager.ts
+++ b/src/interpreter/config/managers/unit/manager.ts
@@ -8,9 +8,9 @@ import { parseExpression } from "@interpreter/parser";
 import { NumberSymbol, NumberWithUnitSymbol } from "@interpreter/symbols";
 import { Interpreter } from "@src/lib";
 import { buildSchemaUri, parseVersionString } from "@src/utils/schema-uri";
-import { type } from "arktype";
+import { ZodError } from "@tokens-studio/schema-validation";
 import { BaseManager } from "../base-manager";
-import { specName, type UnitSpecification, UnitSpecificationSchema } from "./schema";
+import { parseUnitSpec, specName, type UnitSpecification } from "./schema";
 
 // Types -----------------------------------------------------------------------
 
@@ -147,20 +147,18 @@ export class UnitManager extends BaseManager<
   public register(uri: uriType, spec: UnitSpecification | string): UnitSpecification {
     let parsedSpec: UnitSpecification;
 
-    if (typeof spec === "string") {
-      const parseResult = UnitSpecificationSchema(JSON.parse(spec));
-      if (parseResult instanceof type.errors) {
-        throw new Error(
-          `Invalid unit specification for URI ${uri}: ${parseResult.summary}\n\nJson:\n${spec}`,
-        );
-      }
-      parsedSpec = parseResult as UnitSpecification;
-    } else {
-      const parseResult = UnitSpecificationSchema(spec);
-      if (parseResult instanceof type.errors) {
-        throw new Error(`Invalid unit specification for URI ${uri}: ${parseResult.summary}`);
-      }
-      parsedSpec = parseResult as UnitSpecification;
+    try {
+      const input = typeof spec === "string" ? JSON.parse(spec) : spec;
+      parsedSpec = parseUnitSpec(input);
+    } catch (err) {
+      const summary =
+        err instanceof ZodError
+          ? err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ")
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      const jsonSuffix = typeof spec === "string" ? `\n\nJson:\n${spec}` : "";
+      throw new Error(`Invalid unit specification for URI ${uri}: ${summary}${jsonSuffix}`);
     }
 
     this.specs.set(uri, parsedSpec);

--- a/src/interpreter/config/managers/unit/schema.ts
+++ b/src/interpreter/config/managers/unit/schema.ts
@@ -10,7 +10,7 @@
 // `Conversion`, `UnitSpecificationSchema`, `validUnitTypes`) so consumer
 // code does not have to change.
 
-import { Unit } from "@tokens-studio/schema-validation";
+import { Unit, type z } from "@tokens-studio/schema-validation";
 
 // Types -----------------------------------------------------------------------
 
@@ -19,6 +19,12 @@ export type Conversion = Unit.Conversion;
 export type ScriptBlock = Unit.UnitScriptBlock;
 
 // Validation API --------------------------------------------------------------
+//
+// Explicit type annotations on these re-exports are required because
+// tsup's DTS bundling (rollup-plugin-dts) can't construct a public path
+// for the internal types that transitively appear in the inferred
+// return types of `Unit.parseUnitSpec` etc. Without the annotation
+// the DTS emit fails with TS4023 / TS2742.
 
 /**
  * Validate and parse a JSON value as a unit specification. Throws a
@@ -33,13 +39,15 @@ export type ScriptBlock = Unit.UnitScriptBlock;
  * are mathematical and treated as information-preserving. This is a
  * deliberate cross-kind asymmetry with color Conversions.
  */
-export const parseUnitSpec = Unit.parseUnitSpec;
+export const parseUnitSpec: (json: unknown) => UnitSpecification = Unit.parseUnitSpec;
 
 /**
  * Like `parseUnitSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseUnitSpec = Unit.safeParseUnitSpec;
+export const safeParseUnitSpec: (
+	json: unknown,
+) => z.ZodSafeParseResult<UnitSpecification> = Unit.safeParseUnitSpec;
 
 /**
  * Historical compatibility alias for `parseUnitSpec`. Wrap a call in a
@@ -47,7 +55,7 @@ export const safeParseUnitSpec = Unit.safeParseUnitSpec;
  *
  * @deprecated Prefer `parseUnitSpec` / `safeParseUnitSpec`.
  */
-export const UnitSpecificationSchema = Unit.parseUnitSpec;
+export const UnitSpecificationSchema: (json: unknown) => UnitSpecification = Unit.parseUnitSpec;
 
 // Constants -------------------------------------------------------------------
 
@@ -63,4 +71,4 @@ export const validUnitTypes = ["absolute", "relative"] as const;
 // Helpers ---------------------------------------------------------------------
 
 /** Lowercased lookup name for a unit spec. */
-export const specName = Unit.specName;
+export const specName: (spec: UnitSpecification) => string = Unit.specName;

--- a/src/interpreter/config/managers/unit/schema.ts
+++ b/src/interpreter/config/managers/unit/schema.ts
@@ -1,50 +1,66 @@
-import { type } from "arktype";
+// Unit-kind schema shim.
+//
+// Re-exports the typed shapes from @tokens-studio/schema-validation so
+// that the rest of the interpreter can continue importing from
+// "@interpreter/config/managers/unit/schema". The schema-validation
+// package is the cross-language source of truth for the schema language
+// (TS / Go / Ruby).
+//
+// Aliases preserve the historical interpreter names (`ScriptBlock`,
+// `Conversion`, `UnitSpecificationSchema`, `validUnitTypes`) so consumer
+// code does not have to change.
 
-// Script Block Schema
-const ScriptBlockSchema = type({
-  "type?": "string",
-  script: "string",
-});
+import { Unit } from "@tokens-studio/schema-validation";
 
-export interface ScriptBlock {
-  type?: string;
-  script: string;
-}
+// Types -----------------------------------------------------------------------
 
-// Conversion Schema
-const ConversionSchema = type({
-  source: "string",
-  target: "string",
-  script: ScriptBlockSchema,
-  "description?": "string",
-});
+export type UnitSpecification = Unit.UnitSpecification;
+export type Conversion = Unit.Conversion;
+export type ScriptBlock = Unit.UnitScriptBlock;
 
-export interface Conversion {
-  source: string;
-  target: string;
-  script: ScriptBlock;
-  description?: string;
-}
+// Validation API --------------------------------------------------------------
 
-// Unit Specification Schema
-export const UnitSpecificationSchema = type({
-  name: "string",
-  type: "'absolute' | 'relative'",
-  keyword: "string",
-  "description?": "string",
-  "conversions?": ConversionSchema.array(),
-  "to_absolute?": ScriptBlockSchema,
-});
+/**
+ * Validate and parse a JSON value as a unit specification. Throws a
+ * `ZodError` with a structured field-by-field error report on failure.
+ *
+ * Strictness:
+ *   - Top level: unknown fields are tolerated (silently stripped).
+ *   - Nested shapes (Conversion, UnitScriptBlock): unknown fields are
+ *     rejected.
+ *
+ * Note: unit Conversions have NO `lossless` field — unit conversions
+ * are mathematical and treated as information-preserving. This is a
+ * deliberate cross-kind asymmetry with color Conversions.
+ */
+export const parseUnitSpec = Unit.parseUnitSpec;
 
-export interface UnitSpecification {
-  name: string;
-  type: "absolute" | "relative";
-  keyword: string;
-  description?: string;
-  conversions?: Conversion[];
-  to_absolute?: ScriptBlock;
-}
+/**
+ * Like `parseUnitSpec` but returns a `{ success, data | error }`
+ * discriminated union instead of throwing.
+ */
+export const safeParseUnitSpec = Unit.safeParseUnitSpec;
 
-export const specName = (spec: UnitSpecification): string => spec.name.toLowerCase();
+/**
+ * Historical compatibility alias for `parseUnitSpec`. Wrap a call in a
+ * `try { ... } catch (err) { ... }` to handle validation failures.
+ *
+ * @deprecated Prefer `parseUnitSpec` / `safeParseUnitSpec`.
+ */
+export const UnitSpecificationSchema = Unit.parseUnitSpec;
 
+// Constants -------------------------------------------------------------------
+
+/**
+ * The set of valid `type` values for a unit specification.
+ *
+ * Hand-spelled because tsup's DTS bundling drops the value side of
+ * namespaced re-exports — `Unit.UnitType` is reachable as a TYPE but
+ * not as the underlying zod enum value.
+ */
 export const validUnitTypes = ["absolute", "relative"] as const;
+
+// Helpers ---------------------------------------------------------------------
+
+/** Lowercased lookup name for a unit spec. */
+export const specName = Unit.specName;

--- a/src/interpreter/config/managers/unit/schema.ts
+++ b/src/interpreter/config/managers/unit/schema.ts
@@ -45,9 +45,8 @@ export const parseUnitSpec: (json: unknown) => UnitSpecification = Unit.parseUni
  * Like `parseUnitSpec` but returns a `{ success, data | error }`
  * discriminated union instead of throwing.
  */
-export const safeParseUnitSpec: (
-	json: unknown,
-) => z.ZodSafeParseResult<UnitSpecification> = Unit.safeParseUnitSpec;
+export const safeParseUnitSpec: (json: unknown) => z.ZodSafeParseResult<UnitSpecification> =
+  Unit.safeParseUnitSpec;
 
 /**
  * Historical compatibility alias for `parseUnitSpec`. Wrap a call in a

--- a/src/processor/utils/theme-resolver.ts
+++ b/src/processor/utils/theme-resolver.ts
@@ -1,38 +1,52 @@
-import { type } from "arktype";
+import { z } from "@tokens-studio/schema-validation";
 import { isObject } from "@/src/interpreter/utils/type";
 
-// Old format
-const SelectedTokenSetsObjectSchema = type("Record<string, 'enabled' | 'source'>");
+/**
+ * Validation for the `$themes.json` file format used by Figma Tokens
+ * Studio. NOT part of the schema language; this is application config
+ * that travels alongside token sets.
+ *
+ * The `$themes.json` data carries many extra fields beyond what this
+ * resolver consumes (`id`, `$figmaStyleReferences`,
+ * `$figmaCollectionVariableIds`, etc. — Figma plugin bookkeeping).
+ * The schemas below are intentionally LOOSE on every object level: in
+ * zod v4 `z.object()` strips unknown keys silently rather than
+ * failing, which matches what real `$themes.json` files need.
+ */
 
-// New format
-const SelectedTokenSetsArraySchema = type({
-  id: "string",
-  status: "'enabled' | 'source'",
-}).array();
+// Old object format: { "core": "enabled", "semantic": "source" }
+const TokenSetStatus = z.enum(["enabled", "source"]);
+const SelectedTokenSetsObjectSchema = z.record(z.string(), TokenSetStatus);
 
-// For validation, we accept either format
-const SelectedTokenSetsSchema = type([
+// New array format: [{ id: "core", status: "enabled" }]
+const SelectedTokenSetsArraySchema = z.array(
+  z.object({
+    id: z.string(),
+    status: TokenSetStatus,
+  }),
+);
+
+// Either format is accepted.
+const SelectedTokenSetsSchema = z.union([
   SelectedTokenSetsObjectSchema,
-  "|",
   SelectedTokenSetsArraySchema,
 ]);
 
-const ThemeSchema = type({
-  name: "string",
+const ThemeSchema = z.object({
+  name: z.string(),
   selectedTokenSets: SelectedTokenSetsSchema,
-  "figmaCollectionId?": "string",
-  "figmaModeId?": "string",
-  "group?": "string",
+  figmaCollectionId: z.string().optional(),
+  figmaModeId: z.string().optional(),
+  group: z.string().optional(),
 });
 
-// Schema for standalone themes array (like $themes.json)
-const ThemesArraySchema = ThemeSchema.array();
+const ThemesArraySchema = z.array(ThemeSchema);
 
-export type ThemesArray = typeof ThemesArraySchema.infer;
-export type Theme = typeof ThemeSchema.infer;
-export type SelectedTokenSets = typeof SelectedTokenSetsSchema.infer;
-export type SelectedTokenSetsObject = typeof SelectedTokenSetsObjectSchema.infer;
-export type SelectedTokenSetsArray = typeof SelectedTokenSetsArraySchema.infer;
+export type ThemesArray = z.infer<typeof ThemesArraySchema>;
+export type Theme = z.infer<typeof ThemeSchema>;
+export type SelectedTokenSets = z.infer<typeof SelectedTokenSetsSchema>;
+export type SelectedTokenSetsObject = z.infer<typeof SelectedTokenSetsObjectSchema>;
+export type SelectedTokenSetsArray = z.infer<typeof SelectedTokenSetsArraySchema>;
 
 /**
  * Selects a theme by name from an array of themes.
@@ -83,10 +97,15 @@ export const selectThemeOrFirst = (themes: ThemesArray, themeName?: string): The
 /**
  * Resolves themes from collected json.
  *
- * Uses arktype to validate the structure:
- * - Each theme must have a 'name' string property
- * - Each theme must have a 'selectedTokenSets' property (any type)
+ * Validates the structure with zod (via the schema-validation
+ * library's `z` re-export):
+ * - Each theme must have a `name` string property
+ * - Each theme must have a `selectedTokenSets` property in either
+ *   the old object format (`{ name: "enabled" | "source" }`) or the
+ *   new array format (`[{ id, status }]`)
  * - Optional properties: figmaCollectionId, figmaModeId, group
+ * - Extra fields are silently passed through (real-world
+ *   `$themes.json` files carry Figma plugin bookkeeping fields).
  *
  * @param jsonFiles - Record of collected jsons from file-collector
  * @returns Tuple of [path, themes array] or undefined if no valid themes found
@@ -98,18 +117,16 @@ export const resolveThemes = (
   if (themesFile) {
     // First try as an object with $themes property
     if (isObject(themesFile) && "$themes" in themesFile) {
-      const themesValue = themesFile.$themes;
-      const validatedThemes = ThemesArraySchema(themesValue);
-
-      if (!(validatedThemes instanceof type.errors)) {
-        return ["$themes", validatedThemes];
+      const inner = ThemesArraySchema.safeParse(themesFile.$themes);
+      if (inner.success) {
+        return ["$themes", inner.data];
       }
     }
 
     // Then try as a direct array of themes
-    const validatedAsArray = ThemesArraySchema(themesFile);
-    if (!(validatedAsArray instanceof type.errors)) {
-      return ["$themes", validatedAsArray];
+    const direct = ThemesArraySchema.safeParse(themesFile);
+    if (direct.success) {
+      return ["$themes", direct.data];
     }
   }
 

--- a/src/utils/schema-fetcher.ts
+++ b/src/utils/schema-fetcher.ts
@@ -1,33 +1,107 @@
 import { Config } from "@interpreter/config";
 import {
   type ColorSpecification,
-  ColorSpecificationSchema,
+  parseColorSpec,
 } from "@interpreter/config/managers/color/schema";
 import {
   type FunctionSpecification,
-  FunctionSpecificationSchema,
+  parseFunctionSpec,
 } from "@interpreter/config/managers/functions/schema";
-import { type } from "arktype";
+import { ZodError } from "@tokens-studio/schema-validation";
 
-const SchemaContentSchema = ColorSpecificationSchema.or(FunctionSpecificationSchema);
+// The TokenScript schema-server response envelope. The inner `content`
+// is the actual schema specification (color or function); everything else
+// is registry metadata.
+//
+// Validated by hand here rather than via the schema-validation library
+// because the envelope is registry-server specific and not part of the
+// schema language itself. The library handles the inner `content` field.
+export interface TokenScriptSchemaResponse {
+  id: string;
+  type: string;
+  schema: string;
+  slug: string;
+  version: string;
+  content: TokenScriptSchemaContent;
+  license_name?: string | null;
+}
 
-const TokenScriptSchemaResponseSchema = type({
-  id: "string",
-  type: "string",
-  schema: "string",
-  slug: "string",
-  version: "string",
-  content: SchemaContentSchema,
-  "license_name?": "string | null",
-});
-
-export type TokenScriptSchemaResponse = typeof TokenScriptSchemaResponseSchema.infer;
 export type TokenScriptSchemaContent = ColorSpecification | FunctionSpecification;
 
 export interface SchemaFetcherOptions {
   timeout?: number;
   headers?: Record<string, string>;
   signal?: AbortSignal;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function summarizeZodError(err: ZodError): string {
+  return err.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ");
+}
+
+/**
+ * Validate a parsed JSON value as a TokenScriptSchemaResponse envelope
+ * and parse the inner `content` as a color or function specification.
+ *
+ * Throws an `Error` describing the first violation on failure.
+ */
+function parseTokenScriptSchemaResponse(data: unknown): TokenScriptSchemaResponse {
+  if (!isPlainObject(data)) {
+    throw new Error("Invalid schema structure: expected an object");
+  }
+
+  const requireString = (key: string): string => {
+    const value = data[key];
+    if (typeof value !== "string") {
+      throw new Error(`Invalid schema structure: missing or non-string field "${key}"`);
+    }
+    return value;
+  };
+
+  const id = requireString("id");
+  const type = requireString("type");
+  const schema = requireString("schema");
+  const slug = requireString("slug");
+  const version = requireString("version");
+
+  if (!("content" in data)) {
+    throw new Error('Invalid schema structure: missing field "content"');
+  }
+  const rawContent = data.content;
+  if (!isPlainObject(rawContent)) {
+    throw new Error('Invalid schema structure: "content" must be an object');
+  }
+
+  const contentType = rawContent.type;
+  let content: TokenScriptSchemaContent;
+  try {
+    if (contentType === "color") {
+      content = parseColorSpec(rawContent);
+    } else if (contentType === "function") {
+      content = parseFunctionSpec(rawContent);
+    } else {
+      throw new Error(
+        `Unsupported content.type "${String(contentType)}" — expected "color" or "function"`,
+      );
+    }
+  } catch (err) {
+    const detail = err instanceof ZodError ? summarizeZodError(err) : err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid schema structure: content: ${detail}`);
+  }
+
+  let license_name: string | null | undefined;
+  if ("license_name" in data) {
+    const raw = data.license_name;
+    if (raw !== null && raw !== undefined && typeof raw !== "string") {
+      throw new Error('Invalid schema structure: "license_name" must be a string or null');
+    }
+    license_name = raw as string | null | undefined;
+  }
+
+  return { id, type, schema, slug, version, content, license_name };
 }
 
 export async function fetchTokenScriptSchema(
@@ -60,24 +134,17 @@ export async function fetchTokenScriptSchema(
     }
 
     const data = await response.json();
-
-    const validatedData = TokenScriptSchemaResponseSchema(data);
-
-    if (validatedData instanceof type.errors) {
-      throw new Error(`Invalid schema structure: ${validatedData.summary}`);
-    }
-
-    return validatedData;
+    return parseTokenScriptSchemaResponse(data);
   } catch (error) {
     clearTimeout(timeoutId);
-
-    if (error instanceof type.errors) {
-      throw new Error(`Invalid schema structure: ${error.summary}`);
-    }
 
     if (error instanceof Error) {
       if (error.name === "AbortError") {
         throw new Error(`Schema fetch timeout after ${timeout}ms`);
+      }
+      // Validation errors are already wrapped with "Invalid schema structure".
+      if (error.message.startsWith("Invalid schema structure") || error.message.startsWith("HTTP error")) {
+        throw error;
       }
       throw new Error(`Failed to fetch schema: ${error.message}`);
     }

--- a/src/utils/schema-fetcher.ts
+++ b/src/utils/schema-fetcher.ts
@@ -1,8 +1,5 @@
 import { Config } from "@interpreter/config";
-import {
-  type ColorSpecification,
-  parseColorSpec,
-} from "@interpreter/config/managers/color/schema";
+import { type ColorSpecification, parseColorSpec } from "@interpreter/config/managers/color/schema";
 import {
   type FunctionSpecification,
   parseFunctionSpec,
@@ -88,7 +85,12 @@ function parseTokenScriptSchemaResponse(data: unknown): TokenScriptSchemaRespons
       );
     }
   } catch (err) {
-    const detail = err instanceof ZodError ? summarizeZodError(err) : err instanceof Error ? err.message : String(err);
+    const detail =
+      err instanceof ZodError
+        ? summarizeZodError(err)
+        : err instanceof Error
+          ? err.message
+          : String(err);
     throw new Error(`Invalid schema structure: content: ${detail}`);
   }
 
@@ -143,7 +145,10 @@ export async function fetchTokenScriptSchema(
         throw new Error(`Schema fetch timeout after ${timeout}ms`);
       }
       // Validation errors are already wrapped with "Invalid schema structure".
-      if (error.message.startsWith("Invalid schema structure") || error.message.startsWith("HTTP error")) {
+      if (
+        error.message.startsWith("Invalid schema structure") ||
+        error.message.startsWith("HTTP error")
+      ) {
         throw error;
       }
       throw new Error(`Failed to fetch schema: ${error.message}`);

--- a/tests/interpreter/color/schema-minimal.test.ts
+++ b/tests/interpreter/color/schema-minimal.test.ts
@@ -1,25 +1,18 @@
-import { ColorSpecificationSchema, MINIMAL_COLOR_SPECIFICATION } from "@interpreter/config/managers/color/schema";
-import { type } from "arktype";
+import {
+  MINIMAL_COLOR_SPECIFICATION,
+  parseColorSpec,
+} from "@interpreter/config/managers/color/schema";
 import { describe, expect, it } from "vitest";
 
 describe("Minimal Color Specification", () => {
-  it("should always be valid according to ColorSpecificationSchema", () => {
+  it("should always be valid according to parseColorSpec", () => {
     // This test ensures that MINIMAL_COLOR_SPECIFICATION is always valid
-    // and can be used as a default template for new color specifications
-    expect(() => {
-      const result = ColorSpecificationSchema(MINIMAL_COLOR_SPECIFICATION);
-      if (result instanceof type.errors) {
-        throw new Error(result.summary);
-      }
-    }).not.toThrow();
+    // and can be used as a default template for new color specifications.
+    expect(() => parseColorSpec(MINIMAL_COLOR_SPECIFICATION)).not.toThrow();
   });
 
   it("should have the expected minimal structure", () => {
-    const result = ColorSpecificationSchema(MINIMAL_COLOR_SPECIFICATION);
-    if (result instanceof type.errors) {
-      throw new Error(result.summary);
-    }
-    const parsed = result;
+    const parsed = parseColorSpec(MINIMAL_COLOR_SPECIFICATION);
 
     // Verify required fields are present
     expect(parsed.name).toBe("MinimalColor");
@@ -40,17 +33,12 @@ describe("Minimal Color Specification", () => {
   });
 
   it("should be serializable to JSON and back", () => {
-    // Ensure the minimal spec can be safely serialized and deserialized
+    // Ensure the minimal spec can be safely serialized and deserialized.
     const jsonString = JSON.stringify(MINIMAL_COLOR_SPECIFICATION);
     const parsed = JSON.parse(jsonString);
 
     // Should still be valid after JSON round-trip
-    expect(() => {
-      const result = ColorSpecificationSchema(parsed);
-      if (result instanceof type.errors) {
-        throw new Error(result.summary);
-      }
-    }).not.toThrow();
+    expect(() => parseColorSpec(parsed)).not.toThrow();
 
     // Should be identical after round-trip
     expect(parsed).toEqual(MINIMAL_COLOR_SPECIFICATION);

--- a/tests/interpreter/color/schema-minimal.test.ts
+++ b/tests/interpreter/color/schema-minimal.test.ts
@@ -1,7 +1,4 @@
-import {
-  MINIMAL_COLOR_SPECIFICATION,
-  parseColorSpec,
-} from "@interpreter/config/managers/color/schema";
+import { MINIMAL_COLOR_SPECIFICATION, parseColorSpec } from "@interpreter/config/managers/color/schema";
 import { describe, expect, it } from "vitest";
 
 describe("Minimal Color Specification", () => {

--- a/tests/interpreter/config/managers/token/manager.test.ts
+++ b/tests/interpreter/config/managers/token/manager.test.ts
@@ -56,5 +56,4 @@ describe("TokenManager", () => {
     expect(clone.getSpec("test-uri")).toEqual(spec);
     expect(clone).not.toBe(manager);
   });
-
 });

--- a/tests/interpreter/config/managers/token/manager.test.ts
+++ b/tests/interpreter/config/managers/token/manager.test.ts
@@ -57,8 +57,14 @@ describe("TokenManager", () => {
     expect(clone).not.toBe(manager);
   });
 
-  it("should use validations script", () => {
+  it("should accept a per-property validations map on the schema", () => {
     const manager = new TokenManager();
+    // `validations` is a sibling field on Schema, keyed by sub-property
+    // name; it is NOT a property entry of its own. The previous version
+    // of this test put `validations: { script: "..." }` inside
+    // `properties`, which the old loose `Record<string, unknown>` shape
+    // silently accepted but the strict shape correctly rejects (no
+    // `type` field on the would-be Property).
     const spec = {
       name: "border-radius",
       type: "token" as const,
@@ -68,9 +74,9 @@ describe("TokenManager", () => {
           value: {
             type: "number" as const,
           },
-          validations: {
-            script: "Enter script here",
-          },
+        },
+        validations: {
+          value: "Enter script here",
         },
       },
     };

--- a/tests/interpreter/config/managers/token/manager.test.ts
+++ b/tests/interpreter/config/managers/token/manager.test.ts
@@ -57,30 +57,4 @@ describe("TokenManager", () => {
     expect(clone).not.toBe(manager);
   });
 
-  it("should accept a per-property validations map on the schema", () => {
-    const manager = new TokenManager();
-    // `validations` is a sibling field on Schema, keyed by sub-property
-    // name; it is NOT a property entry of its own. The previous version
-    // of this test put `validations: { script: "..." }` inside
-    // `properties`, which the old loose `Record<string, unknown>` shape
-    // silently accepted but the strict shape correctly rejects (no
-    // `type` field on the would-be Property).
-    const spec = {
-      name: "border-radius",
-      type: "token" as const,
-      schema: {
-        type: "object" as const,
-        properties: {
-          value: {
-            type: "number" as const,
-          },
-        },
-        validations: {
-          value: "Enter script here",
-        },
-      },
-    };
-    manager.register("test-uri", JSON.stringify(spec));
-    expect(manager.getSpec("test-uri")).toEqual(spec);
-  });
 });


### PR DESCRIPTION
## Summary

Replaces the hand-rolled [arktype](https://arktype.io) schemas in the config manager layer with the new shared validator [`@tokens-studio/schema-validation`](https://www.npmjs.com/package/@tokens-studio/schema-validation) — the cross-language source of truth for the TokenScript schema language with three independent implementations (TypeScript, Go, Ruby).

## What changes

**Runtime validator swap**

All five kind schema shims now delegate to `@tokens-studio/schema-validation`:

- `src/interpreter/config/managers/token/schema.ts`
- `src/interpreter/config/managers/color/schema.ts`
- `src/interpreter/config/managers/functions/schema.ts`
- `src/interpreter/config/managers/unit/schema.ts`
- `src/interpreter/config/managers/constants/schema.ts`

Each file is now a thin re-export shim: `parse<Kind>Spec`, `safeParse<Kind>Spec`, `<Kind>SpecificationSchema` (historical alias), and `specName`. Historical interpreter type names (`SpecProperty`, `SpecItemsType`, `TokenSpecificationSchema`, `validSchemaTypes`, `MINIMAL_COLOR_SPECIFICATION`, `Conversion`, `ScriptBlock`) are all preserved so no consumer downstream has to change.

**Strictness model**

Mirrors the new lib's two-tier rule:

- **Top level**: unknown fields tolerated (forward compatibility for Figma plugin bookkeeping, token set metadata, etc.)
- **Nested shapes** (Schema, Property, ItemsSpec, ScriptBlock, Initializer, Conversion): unknown fields and unsupported enum values rejected

This is a behavioral change from the previous arktype setup, which was loose by default at every level. It catches typos in property field names (`deescription` → now rejected at the Property level) while staying permissive about plugin-specific extras at the top.

**Theme resolver**

`src/processor/utils/theme-resolver.ts` validates `$themes.json` with its own loose-object schema (using `z` re-exported from the lib) — Figma plugin extras mean theme entries carry unpredictable bookkeeping fields at every level.

**Dropped dependency**

`arktype` removed from `dependencies`. The full validator surface is now `@tokens-studio/schema-validation` + zod (transitively, via the lib).

## Why the explicit type annotations

The lib exposes types via a namespace re-export pattern (`export { ... as Token }`). When tsup bundles the lib with `--dts`, rollup-plugin-dts emits top-level declarations reachable only through the `Token` namespace, with internal prefixed aliases glued between them. Consumers that re-export bare values whose return types transitively reference those internal aliases fail to emit their own .d.ts with `TS4023` and `TS2742`.

The fix is to annotate each re-export explicitly so TypeScript uses the annotation verbatim instead of re-inferring and trying to name internal types:

```ts
// Before — inferred, fails TS4023 on DTS emit
export const parseTokenSpec = Token.parseTokenSpec;

// After — annotated, clean emit
export const parseTokenSpec: (json: unknown) => TokenSpecification = Token.parseTokenSpec;
```

Zero runtime cost (annotations are compile-time only). Applied uniformly to `parse<Kind>Spec`, `safeParse<Kind>Spec`, `<Kind>SpecificationSchema`, and `specName` in all five kind shims.

## Cross-language parity

Every behavioral rule in this PR is also enforced by the Go and Ruby implementations of the same lib, pinned by a shared fixture suite (`fixtures/v1/`) that all three parsers walk in CI. This PR is the first language consumer of the published `@tokens-studio/schema-validation@0.1.0` tarball; the studio-on-rails PR ([The-Phoenix-Will-Fly/studio-on-rails#2050](https://github.com/The-Phoenix-Will-Fly/studio-on-rails/pull/2050)) migrates the Go interpreter in parallel.

## Out of scope

- **Normalization pipeline**. The lib parses the `accepts` field on function properties (the cross-language hook for `SetAlpha(red, 50%)` → 50% normalized to 0.5 before the function script runs) but the TypeScript interpreter does not yet act on it. Only the Go interpreter has the normalization wiring today. TS parity is a clean follow-up and intentionally deferred.
- **Output-format / effect / text registry kinds** (~10 schemas) still have their own local validators in the interpreter — they're outside the lib's current kind coverage.