### PR TITLE
fix(resolver): surface composite sub-field refs on parent graph node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Composite tokens now expose transitive references on their dependency graph node** — for a composite `$value` (typography, shadow, border, or any object/array-shaped value), the parent token's entry in `graph.getNodes()` now lists the concrete referenced tokens reached by walking every sub-field. Previously the parent only listed internal sub-field virtual paths, which made it impossible for consumers of `result.graph` to show forward references for composites.
+
 ## [0.32.0] - 2026-04-07
 
 ### Changed

--- a/src/processor/resolver/TokenResolver.ts
+++ b/src/processor/resolver/TokenResolver.ts
@@ -632,7 +632,13 @@ class PrefixResolver {
       return;
     }
 
-    // Add string fields as virtual tokens
+    // Add string fields as virtual tokens. While parsing each sub-field we
+    // also collect every external reference it points at so the parent can
+    // expose them directly on its graph node — this is the "referenced tokens"
+    // surface consumers expect from `graph.getNodes().get(parent)`.
+    // Using a Set preserves insertion order and deduplicates refs that appear
+    // in multiple sub-fields (e.g. `{dims.unit}` used for both `top` and `bottom`).
+    const subFieldRefs = new Set<RefPath>();
     for (const [fieldPath, fieldValue] of stringFields) {
       this.subFieldPaths.add(fieldPath);
 
@@ -647,12 +653,22 @@ class PrefixResolver {
         continue;
       }
 
+      for (const ref of parser.requiredReferences) {
+        subFieldRefs.add(ref);
+      }
+
       this.processParsedToken(fieldPath, ast, parser.requiredReferences);
     }
 
-    // Parent token depends on all its sub-fields
+    // The parent's graph node lists the concrete tokens it transitively depends
+    // on — not the internal sub-field virtual paths used to sequence resolution.
+    // This keeps `graph.getNodes().get(parent)` useful for consumers that need
+    // to know which real tokens a composite references.
+    this.graph.addNode(tokenName, Array.from(subFieldRefs));
+
+    // The dependency tracker still walks via sub-fields — they are the units
+    // that must resolve before the parent can be assembled.
     const subFieldDeps = Array.from(stringFields.keys());
-    this.graph.addNode(tokenName, subFieldDeps);
     for (const dep of subFieldDeps) {
       this.dependencyTracker.addTokenDependency(tokenName, dep);
     }

--- a/tests/processor/composite-graph-deps.test.ts
+++ b/tests/processor/composite-graph-deps.test.ts
@@ -1,0 +1,203 @@
+import { TokenResolver } from "@src/processor";
+import { describe, expect, it } from "vitest";
+
+/**
+ * These tests cover the bug where composite tokens (typography, shadow, border,
+ * gradient) did not expose their sub-field reference targets on the parent node
+ * of the dependency graph. Consumers that read `graph.getNodes().get(parent)`
+ * (for example, a "referenced tokens" panel in a design-tool UI) need to see
+ * the concrete token names that the parent transitively depends on, not the
+ * internal sub-field paths used during resolution.
+ *
+ * The fix makes the parent's dependency set include every reference reached by
+ * walking the structured value recursively — regardless of nesting depth and
+ * regardless of whether the sub-field value is a single `{ref}` string or an
+ * expression containing multiple refs.
+ */
+describe("TokenResolver dependency graph - composite sub-field references", () => {
+  it("records every sub-field reference on the parent typography node", () => {
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["fontFamilies.sans", { $value: "Inter" }],
+      ["dims.lg", { $value: "24" }],
+      [
+        "typography.heading",
+        {
+          $type: "typography",
+          $value: {
+            fontFamily: "{fontFamilies.sans}",
+            fontSize: "{dims.lg}",
+            fontWeight: "700",
+          },
+        },
+      ],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("typography.heading");
+    expect(deps).toBeDefined();
+    expect(deps?.has("fontFamilies.sans")).toBe(true);
+    expect(deps?.has("dims.lg")).toBe(true);
+  });
+
+  it("records refs from nested object sub-fields (border)", () => {
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["color.border", { $value: "#000" }],
+      ["dims.border", { $value: "2" }],
+      [
+        "border.default",
+        {
+          $type: "border",
+          $value: {
+            color: "{color.border}",
+            width: "{dims.border}",
+            style: "solid",
+          },
+        },
+      ],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("border.default");
+    expect(deps).toBeDefined();
+    expect(deps?.has("color.border")).toBe(true);
+    expect(deps?.has("dims.border")).toBe(true);
+  });
+
+  it("records refs from array-of-object sub-fields (shadow)", () => {
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["color.shadow", { $value: "rgba(0,0,0,0.2)" }],
+      ["dims.blur", { $value: "16" }],
+      ["dims.offset", { $value: "4" }],
+      [
+        "shadow.card",
+        {
+          $type: "shadow",
+          $value: [
+            {
+              color: "{color.shadow}",
+              offsetX: "0",
+              offsetY: "{dims.offset}",
+              blur: "{dims.blur}",
+              spread: "0",
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("shadow.card");
+    expect(deps).toBeDefined();
+    expect(deps?.has("color.shadow")).toBe(true);
+    expect(deps?.has("dims.offset")).toBe(true);
+    expect(deps?.has("dims.blur")).toBe(true);
+  });
+
+  it("records both refs when a sub-field value is an expression with multiple refs", () => {
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["dims.base", { $value: "8" }],
+      ["dims.gap", { $value: "4" }],
+      [
+        "typography.body",
+        {
+          $type: "typography",
+          $value: {
+            fontSize: "{dims.base} + {dims.gap}",
+            fontFamily: "Inter",
+          },
+        },
+      ],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("typography.body");
+    expect(deps).toBeDefined();
+    expect(deps?.has("dims.base")).toBe(true);
+    expect(deps?.has("dims.gap")).toBe(true);
+  });
+
+  it("still reports multiple refs from a top-level expression value", () => {
+    // Sanity-check parity with the composite case — ensures regular tokens
+    // already pick up every ref in an expression (they do; this guards against
+    // regressions in the non-composite path).
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["dims.base", { $value: "8" }],
+      ["dims.gap", { $value: "4" }],
+      ["dims.sum", { $value: "{dims.base} + {dims.gap}" }],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("dims.sum");
+    expect(deps).toBeDefined();
+    expect(deps?.has("dims.base")).toBe(true);
+    expect(deps?.has("dims.gap")).toBe(true);
+  });
+
+  it("deduplicates refs that appear in multiple sub-fields", () => {
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["dims.unit", { $value: "8" }],
+      [
+        "spacing.pair",
+        {
+          $type: "dimension",
+          $value: {
+            top: "{dims.unit}",
+            bottom: "{dims.unit}",
+          },
+        },
+      ],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("spacing.pair");
+    expect(deps).toBeDefined();
+    expect(deps?.has("dims.unit")).toBe(true);
+    // Set deduplication — one entry, not two.
+    let dimsUnitCount = 0;
+    for (const dep of deps ?? []) {
+      if (dep === "dims.unit") dimsUnitCount += 1;
+    }
+    expect(dimsUnitCount).toBe(1);
+  });
+
+  it("records refs from deeply nested sub-fields", () => {
+    const processor = new TokenResolver();
+    const tokens = new Map([
+      ["color.a", { $value: "#111" }],
+      ["color.b", { $value: "#222" }],
+      [
+        "complex.token",
+        {
+          $type: "custom",
+          $value: {
+            outer: {
+              inner: {
+                color: "{color.a}",
+              },
+            },
+            list: [{ color: "{color.b}" }],
+          },
+        },
+      ],
+    ]);
+
+    const result = processor.processTokens(tokens);
+
+    const deps = result.graph.getNodes().get("complex.token");
+    expect(deps).toBeDefined();
+    expect(deps?.has("color.a")).toBe(true);
+    expect(deps?.has("color.b")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

For composite tokens whose `$value` is an object or array (typography, shadow, border, gradient, any nested structure), the parent token's entry in the dependency graph exposed _internal sub-field virtual paths_ as its dependencies rather than the concrete tokens it actually references.

Reading `result.graph.getNodes().get("typography.heading")` for a token with

```json
{
  "$type": "typography",
  "$value": {
    "fontFamily": "{fontFamilies.sans}",
    "fontSize": "{dims.lg}"
  }
}
```

returned `Set { "typography.heading.fontFamily", "typography.heading.fontSize" }` — paths that are _not_ real tokens and therefore cannot be looked up by consumers. A UI that wants to render the set of tokens a composite references (a "forward references" panel, an editor breadcrumb trail, a build tool verifying refs) saw zero matches once those internal paths failed to resolve against the real token list.

Regular scalar tokens (`"{a} + {b}"`) were unaffected because the parser's `requiredReferences` are wired directly into the graph for those.

## Fix

In `PrefixResolver.handleStructuredToken`, while parsing each sub-field we already have `parser.requiredReferences` — the set of concrete token names the sub-field's expression points at. Collect the union of those into an insertion-ordered `Set<RefPath>` and use it as the parent's graph node dependencies instead of the sub-field virtual paths.

- `DependencyTracker` still uses sub-field paths for sequencing resolution, so the order in which tokens resolve is unchanged.
- Sub-field nodes remain in the graph with their own deps (no behaviour change for anyone who walks them).
- Only the _consumer-facing_ `graph.getNodes().get(parent)` surface is affected — it now answers "which tokens does this composite depend on?" truthfully.

The walk is recursive at extraction time (via the existing `extractStringFields` which already walks nested objects and arrays), so nested objects, arrays of objects, and deeply nested composites all work. Expression values with multiple refs (`"{a} + {b}"`) are handled the same way as for regular tokens, since the parser already collects every ref.

## Test plan

New test file `tests/processor/composite-graph-deps.test.ts` covers:

- [x] Typography composite with two sub-field refs — both appear on the parent's graph node
- [x] Border composite (object) — both refs appear on the parent
- [x] Shadow composite (array of objects) — all three refs appear on the parent
- [x] Sub-field value is an expression with multiple refs (`"{a} + {b}"`) — both refs appear
- [x] Dedup: the same ref used in multiple sub-fields appears exactly once on the parent
- [x] Deeply nested (`outer.inner.color`, `list[0].color`) — all refs surfaced
- [x] Sanity: top-level expression with multiple refs still works (regression guard)

Run locally:

```
npm run check:all
# Test Files  91 passed (91)
#      Tests  1894 passed (1894)
```

No existing tests modified; baseline was 1887 passing, now 1894 (= 1887 + 7 new).

## Acceptance criteria

- [x] `graph.getNodes().get("typography.heading")` returns a set containing every sub-field reference target (`fontFamilies.sans`, `dims.lg`) when the typography token has those sub-fields as refs.
- [x] Same for shadow and border composites.
- [x] Expression values with multiple refs (`"{a} + {b}"`) extract both.
- [x] Existing tests pass unchanged.
- [x] New tests added for all three composite types and the multi-ref expression case.