### PR TITLE
feat(resolver): token name validation for invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Token name validation** — the resolver now emits an `INVALID_TOKEN_NAME` error for tokens whose names contain spaces, braces, or brackets. Validation is applied per dot-separated segment, matching the Go and Ruby implementations. Exported `validateTokenName` and `validateTokenPath` utilities for external use.
+
 ## [0.32.0] - 2026-04-07
 
 ### Changed

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -29,6 +29,8 @@ export {
   getModifiedDependants,
   getRenamedReferences,
   TokenResolver,
+  validateTokenName,
+  validateTokenPath,
   ValidationSeverity,
 } from "@src/processor";
 export * as builders from "@src/processor/builders";

--- a/src/lib/processor.ts
+++ b/src/lib/processor.ts
@@ -29,9 +29,9 @@ export {
   getModifiedDependants,
   getRenamedReferences,
   TokenResolver,
+  ValidationSeverity,
   validateTokenName,
   validateTokenPath,
-  ValidationSeverity,
 } from "@src/processor";
 export * as builders from "@src/processor/builders";
 export { processTokenSets, processTokens } from "@src/processor/process";

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -31,7 +31,6 @@ export {
   hasIssueWithCode,
   tokenHasIssueWithCode,
 } from "./resolver/issue-helpers";
-export { validateTokenName, validateTokenPath } from "./utils/name-validation";
 export type { ProcessorOutput, ProcessorResult } from "./resolver/TokenResolver";
 export { TokenResolver } from "./resolver/TokenResolver";
 export type {
@@ -53,5 +52,6 @@ export type {
   ProcessResult,
   ProcessSetsOptions,
 } from "./types";
+export { validateTokenName, validateTokenPath } from "./utils/name-validation";
 export type { ValidationIssue } from "./validator";
 export { ValidationSeverity } from "./validator";

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -31,6 +31,7 @@ export {
   hasIssueWithCode,
   tokenHasIssueWithCode,
 } from "./resolver/issue-helpers";
+export { validateTokenName, validateTokenPath } from "./utils/name-validation";
 export type { ProcessorOutput, ProcessorResult } from "./resolver/TokenResolver";
 export { TokenResolver } from "./resolver/TokenResolver";
 export type {

--- a/src/processor/resolver/TokenResolver.ts
+++ b/src/processor/resolver/TokenResolver.ts
@@ -27,6 +27,7 @@ import {
   type ObjectParser,
 } from "../object-parsers";
 import { DependencyGraph } from "../utils/DependencyGraph";
+import { validateTokenPath } from "../utils/name-validation";
 import { extractStringFields } from "../utils/structured-tokens";
 import { getTokenValue, setTokenValue, type TokenData } from "../utils/tokens";
 import type { ValidationIssue } from "../validator";
@@ -551,6 +552,18 @@ class PrefixResolver {
     this.earlyResolved = [];
 
     for (const [tokenName, tokenData] of this.tokens.entries()) {
+      // Validate token name: each dot-separated segment must not contain
+      // spaces, braces, or brackets.
+      if (!validateTokenPath(tokenName)) {
+        this.addIssue(tokenName, {
+          code: "INVALID_TOKEN_NAME",
+          severity: ValidationSeverity.ERROR,
+          message: `token "${tokenName}" contains invalid characters in name (spaces, braces, or brackets are not allowed)`,
+          tokenName,
+          data: { path: tokenName },
+        });
+      }
+
       const tokenValue = getTokenValue(tokenData);
 
       // Handle uninterpreted keywords

--- a/src/processor/utils/name-validation.ts
+++ b/src/processor/utils/name-validation.ts
@@ -1,0 +1,25 @@
+/**
+ * Token name validation.
+ *
+ * Must stay in sync with the Go and Ruby versions. The shared fixture
+ * at tokenscript/test-suites/token-name-validation.json proves they agree.
+ * Uses explicit whitespace chars (not \s) to ensure identical behavior
+ * across Go/JS/Ruby regex engines.
+ */
+
+const INVALID_TOKEN_NAME_CHARS = /[ \t\n\r\f{}\[\]]/;
+
+/** Returns true if a single name segment is valid: non-empty and contains no whitespace, braces, or brackets. */
+export function validateTokenName(name: string): boolean {
+  return name.length > 0 && !INVALID_TOKEN_NAME_CHARS.test(name);
+}
+
+/** Splits a dot-delimited token path into its name segments. */
+export function splitTokenPath(path: string): string[] {
+  return path.split(".");
+}
+
+/** Returns true if every segment of a dot-delimited token path is a valid token name. */
+export function validateTokenPath(path: string): boolean {
+  return splitTokenPath(path).every(validateTokenName);
+}

--- a/src/processor/utils/name-validation.ts
+++ b/src/processor/utils/name-validation.ts
@@ -7,7 +7,7 @@
  * across Go/JS/Ruby regex engines.
  */
 
-const INVALID_TOKEN_NAME_CHARS = /[ \t\n\r\f{}\[\]]/;
+const INVALID_TOKEN_NAME_CHARS = /[ \t\n\r\f{}[\]]/;
 
 /** Returns true if a single name segment is valid: non-empty and contains no whitespace, braces, or brackets. */
 export function validateTokenName(name: string): boolean {

--- a/tests/processor/name-validation.test.ts
+++ b/tests/processor/name-validation.test.ts
@@ -1,8 +1,8 @@
-import { validateTokenName, validateTokenPath } from "@src/processor/utils/name-validation";
 import { TokenResolver } from "@src/processor";
+import { validateTokenName, validateTokenPath } from "@src/processor/utils/name-validation";
+import type { TokenData } from "@src/processor/utils/tokens";
 import { ValidationSeverity } from "@src/processor/validator";
 import { describe, expect, it } from "vitest";
-import type { TokenData } from "@src/processor/utils/tokens";
 
 describe("name-validation", () => {
   describe("validateTokenName", () => {
@@ -78,9 +78,7 @@ describe("name-validation", () => {
       const issues = result.issues?.get("invalid space name");
       expect(issues).toBeDefined();
       expect(issues!.length).toBeGreaterThanOrEqual(1);
-      const nameIssue = issues!.find(
-        (i) => "code" in i && i.code === "INVALID_TOKEN_NAME",
-      );
+      const nameIssue = issues!.find((i) => "code" in i && i.code === "INVALID_TOKEN_NAME");
       expect(nameIssue).toBeDefined();
       expect(nameIssue!).toMatchObject({
         code: "INVALID_TOKEN_NAME",
@@ -90,33 +88,25 @@ describe("name-validation", () => {
 
     it("flags a token with braces in its name", () => {
       const resolver = new TokenResolver();
-      const tokens = new Map<string, TokenData>([
-        ["color{primary}", { $value: "#ff0000", $type: "color" }],
-      ]);
+      const tokens = new Map<string, TokenData>([["color{primary}", { $value: "#ff0000", $type: "color" }]]);
 
       const result = resolver.processTokens(tokens);
 
       const issues = result.issues?.get("color{primary}");
       expect(issues).toBeDefined();
-      const nameIssue = issues!.find(
-        (i) => "code" in i && i.code === "INVALID_TOKEN_NAME",
-      );
+      const nameIssue = issues!.find((i) => "code" in i && i.code === "INVALID_TOKEN_NAME");
       expect(nameIssue).toBeDefined();
     });
 
     it("flags a token with an invalid segment in a dotted path", () => {
       const resolver = new TokenResolver();
-      const tokens = new Map<string, TokenData>([
-        ["color.Bg Color", { $value: "#ff0000", $type: "color" }],
-      ]);
+      const tokens = new Map<string, TokenData>([["color.Bg Color", { $value: "#ff0000", $type: "color" }]]);
 
       const result = resolver.processTokens(tokens);
 
       const issues = result.issues?.get("color.Bg Color");
       expect(issues).toBeDefined();
-      const nameIssue = issues!.find(
-        (i) => "code" in i && i.code === "INVALID_TOKEN_NAME",
-      );
+      const nameIssue = issues!.find((i) => "code" in i && i.code === "INVALID_TOKEN_NAME");
       expect(nameIssue).toBeDefined();
     });
 

--- a/tests/processor/name-validation.test.ts
+++ b/tests/processor/name-validation.test.ts
@@ -1,0 +1,138 @@
+import { validateTokenName, validateTokenPath } from "@src/processor/utils/name-validation";
+import { TokenResolver } from "@src/processor";
+import { ValidationSeverity } from "@src/processor/validator";
+import { describe, expect, it } from "vitest";
+import type { TokenData } from "@src/processor/utils/tokens";
+
+describe("name-validation", () => {
+  describe("validateTokenName", () => {
+    it("accepts simple names", () => {
+      expect(validateTokenName("color")).toBe(true);
+      expect(validateTokenName("primary")).toBe(true);
+      expect(validateTokenName("Bg_Color")).toBe(true);
+      expect(validateTokenName("spacing-lg")).toBe(true);
+      expect(validateTokenName("100")).toBe(true);
+    });
+
+    it("accepts unicode names", () => {
+      expect(validateTokenName("farbe")).toBe(true);
+      expect(validateTokenName("primär")).toBe(true);
+      expect(validateTokenName("色")).toBe(true);
+      expect(validateTokenName("🔴")).toBe(true);
+    });
+
+    it("rejects empty string", () => {
+      expect(validateTokenName("")).toBe(false);
+    });
+
+    it("rejects names with spaces", () => {
+      expect(validateTokenName("Bg Color")).toBe(false);
+      expect(validateTokenName("  leading")).toBe(false);
+      expect(validateTokenName("trailing  ")).toBe(false);
+    });
+
+    it("rejects names with braces", () => {
+      expect(validateTokenName("color{primary}")).toBe(false);
+      expect(validateTokenName("nested{ref}inside")).toBe(false);
+      expect(validateTokenName("mid {brace")).toBe(false);
+    });
+
+    it("rejects names with brackets", () => {
+      expect(validateTokenName("my[token]")).toBe(false);
+      expect(validateTokenName("bracket]end")).toBe(false);
+    });
+
+    it("rejects names with tabs and newlines", () => {
+      expect(validateTokenName("tab\there")).toBe(false);
+      expect(validateTokenName("color\n")).toBe(false);
+    });
+  });
+
+  describe("validateTokenPath", () => {
+    it("accepts valid dot-separated paths", () => {
+      expect(validateTokenPath("color.primary")).toBe(true);
+      expect(validateTokenPath("a.b.c.d")).toBe(true);
+      expect(validateTokenPath("font-size.base")).toBe(true);
+    });
+
+    it("rejects paths with invalid segments", () => {
+      expect(validateTokenPath("color.Bg Color")).toBe(false);
+      expect(validateTokenPath("with space.in-segment")).toBe(false);
+    });
+  });
+
+  describe("TokenResolver emits INVALID_TOKEN_NAME", () => {
+    it("flags a token with a space in its name", () => {
+      const resolver = new TokenResolver();
+      const tokens = new Map<string, TokenData>([
+        ["color.primary", { $value: "#0066CC", $type: "color" }],
+        ["invalid space name", { $value: "#ff0000", $type: "color" }],
+      ]);
+
+      const result = resolver.processTokens(tokens);
+
+      // Valid token should have no issues
+      expect(result.issues?.get("color.primary")).toBeUndefined();
+
+      // Invalid token should have INVALID_TOKEN_NAME issue
+      const issues = result.issues?.get("invalid space name");
+      expect(issues).toBeDefined();
+      expect(issues!.length).toBeGreaterThanOrEqual(1);
+      const nameIssue = issues!.find(
+        (i) => "code" in i && i.code === "INVALID_TOKEN_NAME",
+      );
+      expect(nameIssue).toBeDefined();
+      expect(nameIssue!).toMatchObject({
+        code: "INVALID_TOKEN_NAME",
+        severity: ValidationSeverity.ERROR,
+      });
+    });
+
+    it("flags a token with braces in its name", () => {
+      const resolver = new TokenResolver();
+      const tokens = new Map<string, TokenData>([
+        ["color{primary}", { $value: "#ff0000", $type: "color" }],
+      ]);
+
+      const result = resolver.processTokens(tokens);
+
+      const issues = result.issues?.get("color{primary}");
+      expect(issues).toBeDefined();
+      const nameIssue = issues!.find(
+        (i) => "code" in i && i.code === "INVALID_TOKEN_NAME",
+      );
+      expect(nameIssue).toBeDefined();
+    });
+
+    it("flags a token with an invalid segment in a dotted path", () => {
+      const resolver = new TokenResolver();
+      const tokens = new Map<string, TokenData>([
+        ["color.Bg Color", { $value: "#ff0000", $type: "color" }],
+      ]);
+
+      const result = resolver.processTokens(tokens);
+
+      const issues = result.issues?.get("color.Bg Color");
+      expect(issues).toBeDefined();
+      const nameIssue = issues!.find(
+        (i) => "code" in i && i.code === "INVALID_TOKEN_NAME",
+      );
+      expect(nameIssue).toBeDefined();
+    });
+
+    it("does not flag valid token names", () => {
+      const resolver = new TokenResolver();
+      const tokens = new Map<string, TokenData>([
+        ["color.primary", { $value: "#0066CC", $type: "color" }],
+        ["spacing-lg", { $value: "24px", $type: "dimension" }],
+        ["Bg_Color", { $value: "#ffffff", $type: "color" }],
+      ]);
+
+      const result = resolver.processTokens(tokens);
+
+      expect(result.issues?.get("color.primary")).toBeUndefined();
+      expect(result.issues?.get("spacing-lg")).toBeUndefined();
+      expect(result.issues?.get("Bg_Color")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
### Added

- **Token name validation** — the resolver now emits an `INVALID_TOKEN_NAME` error for tokens whose names contain spaces, braces, or brackets. Validation is applied per dot-separated segment, matching the Go and Ruby implementations. Exported `validateTokenName` and `validateTokenPath` utilities for external use.