### PR TITLE
fix(parser): support dot-access on all expression types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Parser: dot-access on all expression types** — list literals (`[1, 2, 3].length()`), parenthesized expressions (`(expr).method()`), hex color literals (`#ff0000.red()`), booleans, and null now support dot-access for method calls and property access. Previously these produced parse errors instead of reaching the interpreter.
+
 ## [0.34.0] - 2026-04-30
 
 ### Added

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -659,12 +659,16 @@ export class Parser {
       (token.value === ReservedKeyword.TRUE || token.value === ReservedKeyword.FALSE)
     ) {
       this.eat(TokenType.RESERVED_KEYWORD);
-      return new BooleanNode(token.value === ReservedKeyword.TRUE, token);
+      let boolNode: ASTNode = new BooleanNode(token.value === ReservedKeyword.TRUE, token);
+      boolNode = this.attributeAccess(boolNode);
+      return boolNode;
     }
 
     if (token.type === TokenType.RESERVED_KEYWORD && token.value === ReservedKeyword.NULL) {
       this.eat(TokenType.RESERVED_KEYWORD);
-      return new NullNode(token);
+      let nullNode: ASTNode = new NullNode(token);
+      nullNode = this.attributeAccess(nullNode);
+      return nullNode;
     }
 
     if (token.type === TokenType.NUMBER) {
@@ -719,7 +723,9 @@ export class Parser {
 
     if (token.type === TokenType.HEX_COLOR) {
       this.eat(TokenType.HEX_COLOR);
-      return new HexColorNode(token);
+      let hexNode: ASTNode = new HexColorNode(token);
+      hexNode = this.attributeAccess(hexNode);
+      return hexNode;
     }
 
     // Handle partial string tokens

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -630,7 +630,9 @@ export class Parser {
 
     // Explicit list literal: [expr, expr, ...]
     if (token.type === TokenType.LBLOCK) {
-      return this.explicitList();
+      let node: ASTNode = this.explicitList();
+      node = this.attributeAccess(node);
+      return node;
     }
 
     // Handle unary operators
@@ -698,7 +700,7 @@ export class Parser {
       if (this.currentToken.type === TokenType.FORMAT) {
         return this.format(node);
       }
-      return node;
+      return this.attributeAccess(node);
     }
 
     // Handle partial reference tokens


### PR DESCRIPTION

Allow attribute methods access after literals.

- List literals: `[1, 2, 3].length()`
- Parenthesized expressions: `(expr).method()`
- Hex color literals: `#ff0000.red()`
- Booleans: `true.foo`
- Null: `null.toString()`
