### PR TITLE
fix: support method calls on number literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Number literal dot-access** — method calls on number literals now work correctly (e.g. `1.to_string()`, `1.42.to_string()`). The lexer no longer consumes the method-call dot as part of the number.
+
 ## [0.36.0] - 2026-05-07
 
 ## [0.35.0] - 2026-05-07

--- a/src/interpreter/lexer.ts
+++ b/src/interpreter/lexer.ts
@@ -118,8 +118,12 @@ export class Lexer {
     }
 
     while (isNumber(this.currentChar) || this.currentChar === ".") {
-      // Only allow one decimal point per number
       if (this.currentChar === ".") {
+        // Dot not followed by a digit is a method-call dot (e.g. 1.to_string())
+        if (!isNumber(this.peek())) {
+          break;
+        }
+        // Second dot followed by a digit is genuinely malformed (e.g. 3.3.3)
         if (hasDecimalPoint) {
           this.error(LexerErrorCode.MULTIPLE_DECIMAL_POINTS, {
             value: result + this.currentChar,

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -608,11 +608,12 @@ export class Parser {
   }
 
   private number(): ASTNode {
-    const node = new NumNode(this.currentToken);
+    let node: ASTNode = new NumNode(this.currentToken);
     this.eat(TokenType.NUMBER);
     if (this.currentToken.type === TokenType.FORMAT) {
       return this.format(node);
     }
+    node = this.attributeAccess(node);
     return node;
   }
 

--- a/tests/interpreter/syntax/variables.test.ts
+++ b/tests/interpreter/syntax/variables.test.ts
@@ -224,6 +224,26 @@ describe("Variables - Number Features", () => {
     );
     expect(result?.toString()).toBe("123rem");
   });
+
+  it("should handle integer literal method call (1.to_string())", () => {
+    const result = interpretAndGetVariable(
+      `
+    variable result: String = 1.to_string();
+    `,
+      "result",
+    );
+    expect(result?.toString()).toBe("1");
+  });
+
+  it("should handle decimal literal method call (1.42.to_string())", () => {
+    const result = interpretAndGetVariable(
+      `
+    variable result: String = 1.42.to_string();
+    `,
+      "result",
+    );
+    expect(result?.toString()).toBe("1.42");
+  });
 });
 
 describe("Variables - Boolean Features", () => {


### PR DESCRIPTION
### Fixed

- **Number literal dot-access** — method calls on number literals now work correctly (e.g. `1.to_string()`, `1.42.to_string()`). The lexer no longer consumes the method-call dot as part of the number.