### PR TITLE
feat: support negative list indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Negative list indexing** — `list.get(-1)` returns the last element, `list.get(-2)` the second-to-last, etc.
+
 ## [0.36.2] - 2026-05-07
 
 ### Fixed

--- a/src/interpreter/symbols.ts
+++ b/src/interpreter/symbols.ts
@@ -218,7 +218,10 @@ export const ListImpl = {
   },
 
   get(value: ISymbolType[], indexSymbol: ISymbolType): ISymbolType {
-    const index = indexSymbol.value as number;
+    let index = indexSymbol.value as number;
+    if (index < 0) {
+      index = value.length + index;
+    }
     if (isOutOfBounds(value, index)) {
       throw new InterpreterError(SymbolsErrorCode.INDEX_OUT_OF_RANGE, {
         data: { operation: "get" },


### PR DESCRIPTION
## Added

- **Negative list indexing** — `list.get(-1)` returns the last element, `list.get(-2)` the second-to-last, etc.