### PR TITLE
chore: bump @tokens-studio/schema-validation to ^0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@tokens-studio/schema-validation` to `^0.2.0` — adds support for `description` fields on schema properties
+
 ## [0.37.1] - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.37.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@tokens-studio/schema-validation": "^0.1.0",
+        "@tokens-studio/schema-validation": "^0.2.0",
         "commander": "^14.0.1",
         "readline-sync": "^1.4.10",
         "yauzl": "^3.2.0"
@@ -1126,9 +1126,9 @@
       "license": "MIT"
     },
     "node_modules/@tokens-studio/schema-validation": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@tokens-studio/schema-validation/-/schema-validation-0.1.0.tgz",
-      "integrity": "sha512-dK9U/rxXpEHVzFQb2oxaIA6mPhC/Q4EkSYe7kCy49ncw0At+zbkpUOMbSJF/SqIBtXyR6dze4qbYPB3k1bsvBQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tokens-studio/schema-validation/-/schema-validation-0.2.0.tgz",
+      "integrity": "sha512-0HLqhHv3+aH62vQyC8zNFodItrCSxSQ2uHOSBNGr//W85RQeGWdMCmhJzp6JNAYH1p7mM6gKYvNlbTlkjFpN1g==",
       "license": "MPL-2.0",
       "dependencies": {
         "zod": "^4.1.13"

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "homepage": "https://github.com/tokens-studio/tokenscript-interpreter#readme",
   "dependencies": {
-    "@tokens-studio/schema-validation": "^0.1.0",
+    "@tokens-studio/schema-validation": "^0.2.0",
     "commander": "^14.0.1",
     "readline-sync": "^1.4.10",
     "yauzl": "^3.2.0"


### PR DESCRIPTION
Bumps `@tokens-studio/schema-validation` from `^0.1.0` to `^0.2.0`.

### Why

The gradient token schema in studio-on-rails uses `description` fields on properties. The `0.1.0` schema-validation package rejects unknown keys like `description` during schema registration, causing the TS Registry Compliance CI job to fail.

`0.2.0` adds support for `description` on `Property` and `ItemsSpec` types.

### Changes

- `package.json`: bump dependency version
- `CHANGELOG.md`: add entry under Unreleased